### PR TITLE
ft: add dummy stdio cli flag for compatibility with LSP wrappers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,12 @@ const STYLES: Styles = Styles::styled()
 struct Cli {
     #[command(subcommand)]
     command: Option<Command>,
+
+    // this allows LSP wrapper programs to pass a --stdio flag.
+    // since this is the only supported communication at this time, this
+    // flag can be ignored
+    #[arg(long, global = true)]
+    stdio: bool,
 }
 
 #[derive(clap::Subcommand)]


### PR DESCRIPTION
Some IDE LSP plugins seem to want to add --stdio flag all the time.  Adding this dummy flag allows the program to run without complaining about an unknown CLI flag.