### PR TITLE
Add Nix Flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -44,27 +44,6 @@
             "completion_inheritance"
           ];
 
-          passthru.updateScript = pkgs.writeShellScript "update-php-stubs.sh" ''
-            #! /usr/bin/env nix-shell
-            #! nix-shell -i bash -p bash curl gnused gnugrep nix-prefetch-git jq
-
-            file="${self}/flake.nix"
-
-            version="$(grep -oP 'version = "\K[\d\.]+' "$file")"
-            curl -O "https://raw.githubusercontent.com/AJenbo/phpantom_lsp/refs/tags/$version/stubs.lock"
-            stubsVersion="$(grep -oP 'commit = "\K[^"]+' ./stubs.lock)"
-            rm stubs.lock
-
-            stubsHash="$(
-              nix-prefetch-git --rev "$stubsVersion" "https://github.com/JetBrains/phpstorm-stubs.git" \
-                2> /dev/null \
-                | jq -r '.hash'
-            )"
-
-            sed -i 's/\(rev = "\)[^"]*/\1'"$stubsVersion"'/' "$file"
-            sed -i '/stubsSrc/,/}/ s/\(hash = "\)[^"]*/\1'"$stubsHash"'/'
-          '';
-
           postInstall = ''
             mv $out/bin/phpantom_lsp $out/bin/phpantom-lsp
             ln -s $out/bin/phpantom-lsp $out/bin/phpantom_lsp

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,74 @@
+{
+  description = "Flake for phphantom-lsp (local development)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+
+        manifest = (pkgs.lib.importTOML ./Cargo.toml).package;
+      in
+      {
+        packages.default = self.packages.${system}.phpantom-lsp;
+        packages.phpantom-lsp = pkgs.rustPlatform.buildRustPackage rec {
+          pname = manifest.name;
+          cargoLock.lockFile = ./Cargo.lock;
+          version = manifest.version;
+
+          # Use current directory as the source
+          src = pkgs.lib.cleanSource ./.;
+
+          stubsSrc = pkgs.fetchFromGitHub {
+            owner = "JetBrains";
+            repo = "phpstorm-stubs";
+            rev = "3327932472f512d2eb9e122b19702b335083fd9d";
+            hash = "sha256-WN5DAvaw4FfHBl2AqSo1OcEthUm3lOpikdB78qy3cyY=";
+          };
+
+          postPatch = ''
+            mkdir -p stubs/jetbrains
+            cp -a ${stubsSrc} stubs/jetbrains/phpstorm-stubs
+            chmod u+wx stubs/jetbrains/phpstorm-stubs
+            echo "${stubsSrc.rev}" > stubs/jetbrains/phpstorm-stubs/.commit
+          '';
+
+          checkFlags = [
+            "--test"
+            "completion_inheritance"
+          ];
+
+          passthru.updateScript = pkgs.writeShellScript "update-php-stubs.sh" ''
+            #! /usr/bin/env nix-shell
+            #! nix-shell -i bash -p bash curl gnused gnugrep nix-prefetch-git jq
+
+            file="${self}/flake.nix"
+
+            version="$(grep -oP 'version = "\K[\d\.]+' "$file")"
+            curl -O "https://raw.githubusercontent.com/AJenbo/phpantom_lsp/refs/tags/$version/stubs.lock"
+            stubsVersion="$(grep -oP 'commit = "\K[^"]+' ./stubs.lock)"
+            rm stubs.lock
+
+            stubsHash="$(
+              nix-prefetch-git --rev "$stubsVersion" "https://github.com/JetBrains/phpstorm-stubs.git" \
+                2> /dev/null \
+                | jq -r '.hash'
+            )"
+
+            sed -i 's/\(rev = "\)[^"]*/\1'"$stubsVersion"'/' "$file"
+            sed -i '/stubsSrc/,/}/ s/\(hash = "\)[^"]*/\1'"$stubsHash"'/'
+          '';
+
+          postInstall = ''
+            mv $out/bin/phpantom_lsp $out/bin/phpantom-lsp
+            ln -s $out/bin/phpantom-lsp $out/bin/phpantom_lsp
+          '';
+        };
+      });
+}


### PR DESCRIPTION
Add flake for nix support.

This allows to any nix user to directly use the project directly from GitHub from the last version.

Currently, there is an open PR to add it to the nixpkgs. https://github.com/NixOS/nixpkgs/pull/504192 but even it is already old with version 0.6 this allows to nix users to just grab the latest version.

Let me know what you think.


PD: Awesome to find the project looks superb I have been testing it a bit and is great thanks for the Work.