### PR TITLE
Use stub lock instead of fixed version

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,18 +6,45 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = import nixpkgs {
           inherit system;
         };
 
         manifest = (pkgs.lib.importTOML ./Cargo.toml).package;
+        stubsLock = pkgs.lib.importTOML ./stubs.lock;
+        repoParts = pkgs.lib.splitString "/" stubsLock.repo;
+
+        owner = builtins.elemAt repoParts 0;
+        repo = builtins.elemAt repoParts 1;
+
+        stubsTarball = pkgs.fetchurl {
+          url = "https://github.com/${owner}/${repo}/archive/${stubsLock.commit}.tar.gz";
+
+          # convert hex → SRI
+          hash = builtins.convertHash {
+            hash = stubsLock.sha256;
+            hashAlgo = "sha256";
+            toHashFormat = "sri";
+          };
+        };
+
+        stubsSrc = pkgs.runCommand "phpstorm-stubs" { } ''
+          mkdir -p $out
+          tar -xzf ${stubsTarball} --strip-components=1 -C $out
+        '';
       in
       {
         packages.default = self.packages.${system}.phpantom-lsp;
-        packages.phpantom-lsp = pkgs.rustPlatform.buildRustPackage rec {
+        packages.phpantom-lsp = pkgs.rustPlatform.buildRustPackage {
           pname = manifest.name;
           cargoLock.lockFile = ./Cargo.lock;
           version = manifest.version;
@@ -25,18 +52,11 @@
           # Use current directory as the source
           src = pkgs.lib.cleanSource ./.;
 
-          stubsSrc = pkgs.fetchFromGitHub {
-            owner = "JetBrains";
-            repo = "phpstorm-stubs";
-            rev = "3327932472f512d2eb9e122b19702b335083fd9d";
-            hash = "sha256-WN5DAvaw4FfHBl2AqSo1OcEthUm3lOpikdB78qy3cyY=";
-          };
-
           postPatch = ''
             mkdir -p stubs/jetbrains
             cp -a ${stubsSrc} stubs/jetbrains/phpstorm-stubs
             chmod u+wx stubs/jetbrains/phpstorm-stubs
-            echo "${stubsSrc.rev}" > stubs/jetbrains/phpstorm-stubs/.commit
+            echo "${stubsLock.commit}" > stubs/jetbrains/phpstorm-stubs/.commit
           '';
 
           checkFlags = [
@@ -49,5 +69,6 @@
             ln -s $out/bin/phpantom-lsp $out/bin/phpantom_lsp
           '';
         };
-      });
+      }
+    );
 }


### PR DESCRIPTION
Something I didn't realize before was that I fixed the stub version which lead to a test failure due being updated.

I found that there is the subs.lock in the project, so I updated to link it directly to it to not have to update manually.

Thanks.