### PR TITLE
ci: add publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+---
+name: Publish
+
+on:
+  push:
+    tags: ["*"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  crates:
+    name: Publish Rust package
+    runs-on: ubuntu-latest
+    container:
+      image: rust:latest
+    environment:
+      name: crates
+      url: https://crates.io/crates/phpantom_lsp
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Install toml-cli
+        run: cargo install toml-cli
+      - name: Check version
+        run: test "$(toml get -r Cargo.toml package.version)" = "${{ github.ref_name }}"
+      - name: Publish to crates.io
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
This adds a ci job to automatically publish to crates.io when a tag is pushed

> [!NOTE]
> You will need to crate an api token on crates.io and add it as a secret named `CARGO_REGISTRY_TOKEN`

Reference: https://fassbender.dev/blog/001-cargo-publish-action/