### PR TITLE
"Find all references" and rename action for @property/@method in PHPDoc

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Machine-readable CLI output.** Both `analyze` and `fix` accept a `--format` flag with `table`, `github`, and `json` options. When `GITHUB_ACTIONS` is set, table output automatically includes GitHub annotations.
 - **Magic property diagnostics.** New `report-magic-properties` option under `[diagnostics]` in `.phpantom.toml`. When enabled, classes with `__get` that also have virtual properties (from `@property` docblock tags, Laravel Eloquent column inference, or other providers) will flag unknown property access instead of silently allowing it.
 - **Inline diagnostic suppression.** `// @phpantom-ignore code` on the same line or the line above suppresses the specified diagnostic. Multiple codes can be comma-separated. A bare `// @phpantom-ignore` suppresses all diagnostics on the target line.
+- **Find references and rename for PHPDoc virtual members.** `@property`, `@property-read`, `@property-write`, and `@method` declarations in docblocks are now included in find-references and rename results alongside their runtime usages. (thanks @AbyssWaIker)
 
 ### Changed
 

--- a/examples/laravel/app/Demo.php
+++ b/examples/laravel/app/Demo.php
@@ -120,6 +120,7 @@ class Demo
         $top = $reviews->topRated();           // custom method from ReviewCollection
         $avg = $reviews->averageRating();       // custom method from ReviewCollection
         $reviews->first();                // inherited — returns Review|null
+        echo count($top), $avg;
 
         // Relationship properties also use the custom collection
         $review = new Review();
@@ -133,7 +134,8 @@ class Demo
     {
         // Eloquent chunk — $orders inferred as Collection
         BlogAuthor::where('active', true)->chunk(100, function ($orders) {
-            $total = $orders->count();    // resolves to Eloquent Collection
+            $count = $orders->count();    // resolves to Eloquent Collection
+            echo $count;
         });
 
         // Explicit bare type hint inherits inferred generic args for foreach
@@ -213,7 +215,24 @@ class Demo
     }
 
 
-    // ── Laravel Config (definition & references) ────────────────────────────
+    // ── PHPDoc Virtual Member References & Rename ───────────────────────────
+    // Try: right-click "displayName" or "bio" below and use
+    //   • Find All References — includes the @property/@method declaration
+    //   • Rename Symbol — renames in the docblock AND all usage sites
+
+    public function phpdocVirtualMembers(): void
+    {
+        $author = new BlogAuthor();
+        $author->displayName;           // @property-read on BlogAuthor
+        $author->bio();                 // @method on BlogAuthor
+
+        $found = BlogAuthor::where('active', true)->first();
+        $found->displayName;
+        $found->bio();
+    }
+
+
+    // ── Laravel Config (definition & references) ────────────────────────
 
     public function laravelConfig(): void
     {

--- a/examples/laravel/app/Models/BlogAuthor.php
+++ b/examples/laravel/app/Models/BlogAuthor.php
@@ -8,12 +8,13 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
-#[CollectedBy(AuthorCollection::class)]
-
 /**
+ * @property-read string $displayName
+ * @method string bio()
  * @method static Builder<static> withTrashed(bool $withTrashed = true)
  * @method static Builder<static> onlyTrashed()
  */
+#[CollectedBy(AuthorCollection::class)]
 class BlogAuthor extends Model
 {
     protected $fillable = ['name', 'email', 'genre'];

--- a/src/references/mod.rs
+++ b/src/references/mod.rs
@@ -774,8 +774,19 @@ impl Backend {
                         // Check if the enclosing class is in the hierarchy.
                         if let Some(hier) = hierarchy {
                             let ctx = file_ctx_cell.get_or_init(|| self.file_context(file_uri));
-                            if let Some(enclosing) = find_class_at_offset(&ctx.classes, span.start)
-                            {
+                            let enclosing =
+                                find_class_at_offset(&ctx.classes, span.start).or_else(|| {
+                                    // Docblock MemberDeclaration spans are before the
+                                    // opening brace; fall back to the nearest class.
+                                    ctx.classes
+                                        .iter()
+                                        .map(|c| c.as_ref())
+                                        .filter(|c| {
+                                            c.keyword_offset > 0 && span.start < c.start_offset
+                                        })
+                                        .min_by_key(|c| c.start_offset)
+                                });
+                            if let Some(enclosing) = enclosing {
                                 let fqn = enclosing.fqn().to_string();
                                 if !hier.contains(&fqn) {
                                     continue;
@@ -1045,7 +1056,16 @@ impl Backend {
             .get(uri)
             .cloned()
             .unwrap_or_default();
-        let current_class = find_class_at_offset(&classes, offset)?;
+        let current_class = find_class_at_offset(&classes, offset).or_else(|| {
+            // Fallback: offset may be in a class docblock (before the opening
+            // brace).  Find the nearest class whose body starts past the
+            // offset, meaning its docblock region likely contains the offset.
+            classes
+                .iter()
+                .map(|c| c.as_ref())
+                .filter(|c| c.keyword_offset > 0 && offset < c.start_offset)
+                .min_by_key(|c| c.start_offset)
+        })?;
         let fqn = current_class.fqn().to_string();
         Some(self.collect_hierarchy_for_fqns(&[fqn]))
     }

--- a/src/references/tests.rs
+++ b/src/references/tests.rs
@@ -1391,3 +1391,301 @@ async fn test_this_method_references_excludes_unrelated() {
         lines
     );
 }
+
+// ─── PHPDoc @property and @method References ────────────────────────────────
+
+#[tokio::test]
+async fn test_phpdoc_property_references_from_usage() {
+    let backend = Backend::new_test();
+    let uri = Url::parse("file:///test.php").unwrap();
+    let text = concat!(
+        "<?php\n",                              // L0
+        "/**\n",                                // L1
+        " * @property string $email\n",         // L2
+        " */\n",                                // L3
+        "class User {\n",                       // L4
+        "    public function demo(): void {\n", // L5
+        "        echo $this->email;\n",         // L6
+        "    }\n",                              // L7
+        "}\n",                                  // L8
+        "$u = new User();\n",                   // L9
+        "echo $u->email;\n",                    // L10
+    );
+
+    open_file(&backend, &uri, text).await;
+
+    // Click on "email" at line 10 ($u->email).
+    let locs = find_references(&backend, &uri, 10, 13, true).await;
+    assert!(
+        locs.len() >= 3,
+        "Expected at least 3 references to email (declaration + 2 usages), got {}",
+        locs.len()
+    );
+
+    // Should include the @property declaration (line 2).
+    let has_declaration = locs.iter().any(|l| l.range.start.line == 2);
+    assert!(
+        has_declaration,
+        "Should include the @property declaration on line 2"
+    );
+
+    // Should include the $this->email usage (line 6).
+    let has_this_usage = locs.iter().any(|l| l.range.start.line == 6);
+    assert!(
+        has_this_usage,
+        "Should include the $this->email usage on line 6"
+    );
+
+    // Should include the $u->email usage (line 10).
+    let has_external_usage = locs.iter().any(|l| l.range.start.line == 10);
+    assert!(
+        has_external_usage,
+        "Should include the $u->email usage on line 10"
+    );
+}
+
+#[tokio::test]
+async fn test_phpdoc_property_references_from_declaration() {
+    let backend = Backend::new_test();
+    let uri = Url::parse("file:///test.php").unwrap();
+    let text = concat!(
+        "<?php\n",                              // L0
+        "/**\n",                                // L1
+        " * @property string $email\n",         // L2
+        " */\n",                                // L3
+        "class User {\n",                       // L4
+        "    public function demo(): void {\n", // L5
+        "        echo $this->email;\n",         // L6
+        "    }\n",                              // L7
+        "}\n",                                  // L8
+        "$u = new User();\n",                   // L9
+        "echo $u->email;\n",                    // L10
+    );
+
+    open_file(&backend, &uri, text).await;
+
+    // Click on "email" in the @property tag (line 2).
+    // Line: " * @property string $email"
+    // The MemberDeclaration span covers "email" (without $) starting at char 22.
+    let locs = find_references(&backend, &uri, 2, 22, true).await;
+    assert!(
+        locs.len() >= 3,
+        "Expected at least 3 references from @property declaration, got {}",
+        locs.len()
+    );
+}
+
+#[tokio::test]
+async fn test_phpdoc_method_references_from_usage() {
+    let backend = Backend::new_test();
+    let uri = Url::parse("file:///test.php").unwrap();
+    let text = concat!(
+        "<?php\n",                        // L0
+        "/**\n",                          // L1
+        " * @method string getEmail()\n", // L2
+        " */\n",                          // L3
+        "class User {\n",                 // L4
+        "}\n",                            // L5
+        "$u = new User();\n",             // L6
+        "echo $u->getEmail();\n",         // L7
+    );
+
+    open_file(&backend, &uri, text).await;
+
+    // Click on "getEmail" at line 7 ($u->getEmail()).
+    let locs = find_references(&backend, &uri, 7, 10, true).await;
+    assert!(
+        locs.len() >= 2,
+        "Expected at least 2 references to getEmail (declaration + usage), got {}",
+        locs.len()
+    );
+
+    // Should include the @method declaration (line 2).
+    let has_declaration = locs.iter().any(|l| l.range.start.line == 2);
+    assert!(
+        has_declaration,
+        "Should include the @method declaration on line 2"
+    );
+}
+
+#[tokio::test]
+async fn test_phpdoc_property_references_exclude_unrelated_class() {
+    let backend = Backend::new_test();
+    let uri = Url::parse("file:///test.php").unwrap();
+    let text = concat!(
+        "<?php\n",                      // L0
+        "/**\n",                        // L1
+        " * @property string $email\n", // L2
+        " */\n",                        // L3
+        "class User {}\n",              // L4
+        "/**\n",                        // L5
+        " * @property int $email\n",    // L6
+        " */\n",                        // L7
+        "class Order {}\n",             // L8
+        "$u = new User();\n",           // L9
+        "echo $u->email;\n",            // L10
+        "$o = new Order();\n",          // L11
+        "echo $o->email;\n",            // L12
+    );
+
+    open_file(&backend, &uri, text).await;
+
+    // Click on "email" at line 10 ($u->email).
+    let locs = find_references(&backend, &uri, 10, 13, true).await;
+
+    // Should include User's @property and $u->email, but NOT Order's @property or $o->email.
+    let has_user_declaration = locs.iter().any(|l| l.range.start.line == 2);
+    let has_user_usage = locs.iter().any(|l| l.range.start.line == 10);
+    let has_order_declaration = locs.iter().any(|l| l.range.start.line == 6);
+    let has_order_usage = locs.iter().any(|l| l.range.start.line == 12);
+
+    assert!(
+        has_user_declaration,
+        "Should include User's @property declaration"
+    );
+    assert!(has_user_usage, "Should include $u->email usage");
+    assert!(
+        !has_order_declaration,
+        "Should NOT include Order's @property declaration"
+    );
+    assert!(!has_order_usage, "Should NOT include $o->email usage");
+}
+
+#[tokio::test]
+async fn test_phpdoc_property_multiple_properties() {
+    let backend = Backend::new_test();
+    let uri = Url::parse("file:///test.php").unwrap();
+    let text = concat!(
+        "<?php\n",                      // L0
+        "/**\n",                        // L1
+        " * @property int $id\n",       // L2
+        " * @property string $email\n", // L3
+        " * @property string $name\n",  // L4
+        " */\n",                        // L5
+        "class User {}\n",              // L6
+        "$u = new User();\n",           // L7
+        "echo $u->email;\n",            // L8
+    );
+
+    open_file(&backend, &uri, text).await;
+
+    // Click on "email" at line 8 ($u->email).
+    let locs = find_references(&backend, &uri, 8, 13, true).await;
+    assert!(
+        locs.len() >= 2,
+        "Expected at least 2 references to email, got {}",
+        locs.len()
+    );
+
+    // Should include only the @property string $email declaration (line 3), not id or name.
+    let has_email_decl = locs.iter().any(|l| l.range.start.line == 3);
+    let has_id_decl = locs.iter().any(|l| l.range.start.line == 2);
+    let has_name_decl = locs.iter().any(|l| l.range.start.line == 4);
+    assert!(
+        has_email_decl,
+        "Should include @property string $email declaration"
+    );
+    assert!(
+        !has_id_decl,
+        "Should NOT include @property int $id declaration"
+    );
+    assert!(
+        !has_name_decl,
+        "Should NOT include @property string $name declaration"
+    );
+}
+
+#[tokio::test]
+async fn test_phpdoc_property_read_write_variants() {
+    let backend = Backend::new_test();
+    let uri = Url::parse("file:///test.php").unwrap();
+    let text = concat!(
+        "<?php\n",                          // L0
+        "/**\n",                            // L1
+        " * @property-read string $name\n", // L2
+        " * @property-write int $age\n",    // L3
+        " */\n",                            // L4
+        "class User {}\n",                  // L5
+        "$u = new User();\n",               // L6
+        "echo $u->name;\n",                 // L7
+    );
+
+    open_file(&backend, &uri, text).await;
+
+    // Click on "name" at line 7 ($u->name).
+    let locs = find_references(&backend, &uri, 7, 13, true).await;
+    assert!(
+        locs.len() >= 2,
+        "Expected at least 2 references to name (property-read declaration + usage), got {}",
+        locs.len()
+    );
+
+    // Should include the @property-read declaration (line 2).
+    let has_read_decl = locs.iter().any(|l| l.range.start.line == 2);
+    assert!(
+        has_read_decl,
+        "Should include the @property-read declaration"
+    );
+}
+
+#[tokio::test]
+async fn test_phpdoc_method_references_from_declaration() {
+    let backend = Backend::new_test();
+    let uri = Url::parse("file:///test.php").unwrap();
+    let text = concat!(
+        "<?php\n",                        // L0
+        "/**\n",                          // L1
+        " * @method string getEmail()\n", // L2
+        " */\n",                          // L3
+        "class User {}\n",                // L4
+        "$u = new User();\n",             // L5
+        "echo $u->getEmail();\n",         // L6
+    );
+
+    open_file(&backend, &uri, text).await;
+
+    // Click on "getEmail" in the @method tag (line 2).
+    // Line: " * @method string getEmail()"
+    // The MemberDeclaration span covers "getEmail" starting at char 19.
+    let locs = find_references(&backend, &uri, 2, 19, true).await;
+    assert!(
+        locs.len() >= 2,
+        "Expected at least 2 references from @method declaration, got {}",
+        locs.len()
+    );
+
+    let has_usage = locs.iter().any(|l| l.range.start.line == 6);
+    assert!(has_usage, "Should include $u->getEmail() usage on line 6");
+}
+
+#[tokio::test]
+async fn test_phpdoc_method_no_return_type_references() {
+    let backend = Backend::new_test();
+    let uri = Url::parse("file:///test.php").unwrap();
+    let text = concat!(
+        "<?php\n",                 // L0
+        "/**\n",                   // L1
+        " * @method getEmail()\n", // L2
+        " */\n",                   // L3
+        "class User {}\n",         // L4
+        "$u = new User();\n",      // L5
+        "echo $u->getEmail();\n",  // L6
+    );
+
+    open_file(&backend, &uri, text).await;
+
+    // Click on "getEmail" at line 6 ($u->getEmail()).
+    let locs = find_references(&backend, &uri, 6, 10, true).await;
+    assert!(
+        locs.len() >= 2,
+        "Expected at least 2 references to getEmail (declaration + usage), got {}",
+        locs.len()
+    );
+
+    // Should include the @method declaration (line 2).
+    let has_declaration = locs.iter().any(|l| l.range.start.line == 2);
+    assert!(
+        has_declaration,
+        "Should include the @method declaration on line 2"
+    );
+}

--- a/src/rename/tests.rs
+++ b/src/rename/tests.rs
@@ -2939,3 +2939,213 @@ async fn rename_namespace_multiple_files_same_namespace() {
         result_c
     );
 }
+
+// --- PHPDoc @property and @method rename tests ---
+
+#[tokio::test]
+async fn test_prepare_rename_phpdoc_property() {
+    let backend = Backend::new_test();
+    let uri = Url::parse("file:///test.php").unwrap();
+    let text = concat!(
+        "<?php\n",
+        "/**\n",
+        " * @property string $email\n",
+        " */\n",
+        "class User {\n",
+        "    public function demo(): void {\n",
+        "        echo $this->email;\n",
+        "    }\n",
+        "}\n",
+    );
+
+    open_file(&backend, &uri, text).await;
+
+    // Click on "email" in @property tag (line 2, char 22).
+    let result = prepare_rename(&backend, &uri, 2, 22).await;
+    assert!(
+        result.is_some(),
+        "prepare_rename should succeed on @property tag name"
+    );
+}
+
+#[tokio::test]
+async fn rename_phpdoc_property_from_usage() {
+    let backend = Backend::new_test();
+    let uri = Url::parse("file:///test.php").unwrap();
+    let text = concat!(
+        "<?php\n",
+        "/**\n",
+        " * @property string $email\n",
+        " */\n",
+        "class User {\n",
+        "    public function demo(): void {\n",
+        "        echo $this->email;\n",
+        "    }\n",
+        "}\n",
+        "$u = new User();\n",
+        "echo $u->email;\n",
+    );
+
+    open_file(&backend, &uri, text).await;
+
+    // Rename from $u->email usage (line 10, "email" at char 13).
+    let edit = rename(&backend, &uri, 10, 13, "emailAddress").await;
+    assert!(
+        edit.is_some(),
+        "Expected a workspace edit for @property rename"
+    );
+
+    let file_edits = edits_for_uri(&edit.unwrap(), &uri);
+    // Should have edits for: @property declaration, $this->email, $u->email.
+    assert!(
+        file_edits.len() >= 3,
+        "Expected at least 3 edits for @property rename, got {}",
+        file_edits.len()
+    );
+
+    // Verify that the @property declaration was included.
+    let has_decl_edit = file_edits.iter().any(|te| te.range.start.line == 2);
+    assert!(
+        has_decl_edit,
+        "Should include an edit for the @property declaration on line 2"
+    );
+}
+
+#[tokio::test]
+async fn rename_phpdoc_property_from_declaration() {
+    let backend = Backend::new_test();
+    let uri = Url::parse("file:///test.php").unwrap();
+    let text = concat!(
+        "<?php\n",
+        "/**\n",
+        " * @property string $email\n",
+        " */\n",
+        "class User {\n",
+        "    public function demo(): void {\n",
+        "        echo $this->email;\n",
+        "    }\n",
+        "}\n",
+    );
+
+    open_file(&backend, &uri, text).await;
+
+    // Rename from the @property declaration (line 2, char 22).
+    let edit = rename(&backend, &uri, 2, 22, "emailAddress").await;
+    assert!(
+        edit.is_some(),
+        "Expected a workspace edit for @property rename from declaration"
+    );
+
+    let file_edits = edits_for_uri(&edit.unwrap(), &uri);
+    assert!(
+        file_edits.len() >= 2,
+        "Expected at least 2 edits (@property + $this->email), got {}",
+        file_edits.len()
+    );
+
+    // Verify $this->email usage was updated.
+    let has_usage_edit = file_edits.iter().any(|te| te.range.start.line == 6);
+    assert!(
+        has_usage_edit,
+        "Should include an edit for the $this->email usage on line 6"
+    );
+}
+
+#[tokio::test]
+async fn test_rename_phpdoc_method_from_usage() {
+    let backend = Backend::new_test();
+    let uri = Url::parse("file:///test.php").unwrap();
+    let text = concat!(
+        "<?php\n",
+        "/**\n",
+        " * @method string getEmail()\n",
+        " */\n",
+        "class User {}\n",
+        "$u = new User();\n",
+        "echo $u->getEmail();\n",
+    );
+
+    open_file(&backend, &uri, text).await;
+
+    // Rename from $u->getEmail() usage (line 6, "getEmail" at char 10).
+    let edit = rename(&backend, &uri, 6, 10, "getEmailAddress").await;
+    assert!(
+        edit.is_some(),
+        "Expected a workspace edit for @method rename"
+    );
+
+    let file_edits = edits_for_uri(&edit.unwrap(), &uri);
+    // Should have edits for: @method declaration + $u->getEmail() usage.
+    assert!(
+        file_edits.len() >= 2,
+        "Expected at least 2 edits for @method rename, got {}",
+        file_edits.len()
+    );
+
+    // Verify @method declaration was updated.
+    let has_decl_edit = file_edits.iter().any(|te| te.range.start.line == 2);
+    assert!(
+        has_decl_edit,
+        "Should include an edit for the @method declaration on line 2"
+    );
+}
+
+#[tokio::test]
+async fn test_prepare_rename_phpdoc_method() {
+    let backend = Backend::new_test();
+    let uri = Url::parse("file:///test.php").unwrap();
+    let text = concat!(
+        "<?php\n",
+        "/**\n",
+        " * @method string getEmail()\n",
+        " */\n",
+        "class User {}\n",
+    );
+
+    open_file(&backend, &uri, text).await;
+
+    // Click on "getEmail" in @method tag (line 2, char 19).
+    let result = prepare_rename(&backend, &uri, 2, 19).await;
+    assert!(
+        result.is_some(),
+        "prepare_rename should succeed on @method tag name"
+    );
+}
+
+#[tokio::test]
+async fn rename_phpdoc_property_does_not_leak_to_unrelated_class() {
+    let backend = Backend::new_test();
+    let uri = Url::parse("file:///test.php").unwrap();
+    let text = concat!(
+        "<?php\n",
+        "/**\n",
+        " * @property string $email\n",
+        " */\n",
+        "class User {}\n",
+        "/**\n",
+        " * @property int $email\n",
+        " */\n",
+        "class Order {}\n",
+        "$u = new User();\n",
+        "echo $u->email;\n",
+        "$o = new Order();\n",
+        "echo $o->email;\n",
+    );
+
+    open_file(&backend, &uri, text).await;
+
+    // Rename from $u->email (line 11, char 13).
+    let edit = rename(&backend, &uri, 11, 13, "emailAddress").await;
+    assert!(edit.is_some());
+
+    let file_edits = edits_for_uri(&edit.unwrap(), &uri);
+
+    // Should NOT include edits for Order's @property or $o->email.
+    let has_order_decl = file_edits.iter().any(|te| te.range.start.line == 7);
+    let has_order_usage = file_edits.iter().any(|te| te.range.start.line == 13);
+    assert!(
+        !has_order_decl,
+        "Should NOT edit Order's @property declaration"
+    );
+    assert!(!has_order_usage, "Should NOT edit $o->email usage");
+}

--- a/src/symbol_map/docblock.rs
+++ b/src/symbol_map/docblock.rs
@@ -232,6 +232,20 @@ pub(super) fn extract_docblock_symbols(
             continue;
         }
 
+        // ── @property variants ───────────────────────────────────────
+        if matches!(
+            tag.kind,
+            TagKind::Property
+                | TagKind::PropertyRead
+                | TagKind::PropertyWrite
+                | TagKind::PsalmProperty
+                | TagKind::PsalmPropertyRead
+                | TagKind::PsalmPropertyWrite
+        ) {
+            extract_property_tag_symbols(docblock, desc_start_in_docblock, base_offset, spans);
+            continue;
+        }
+
         // ── @template variants ──────────────────────────────────────
         if let Some(variance) = template_variance_for_tag(&tag.kind) {
             if let Some((name, offset, bound)) =
@@ -1131,7 +1145,9 @@ fn extract_method_tag_symbols(
     let mut rest_offset_in_docblock = desc_start_in_docblock + leading_ws;
 
     // Skip optional `static` keyword.
+    let mut is_static = false;
     if rest.starts_with("static ") || rest.starts_with("static\t") {
+        is_static = true;
         let skip = "static".len();
         let after_static = rest[skip..].trim_start();
         let whitespace_len = rest.len() - skip - after_static.len();
@@ -1145,6 +1161,38 @@ fn extract_method_tag_symbols(
 
     // Extract return type.
     let (return_type, remainder) = split_type_token(rest);
+
+    // When the method has no explicit return type (e.g. `@method foo()`),
+    // `split_type_token` consumes `foo()` as the "type" because the
+    // parentheses are treated as a grouped type unit.  Detect this by
+    // checking if `return_type` contains `(` and `remainder` is empty.
+    // In that case, re-split at the method-name `(`.
+    let (return_type, remainder): (&str, &str) =
+        if remainder.is_empty() && return_type.contains('(') {
+            // The "type" is actually `name(params)`.  Split at the first
+            // `(` that follows a valid identifier to separate the method
+            // name from its parameters.
+            if let Some(paren) = return_type.find('(') {
+                let before = &return_type[..paren];
+                // Only re-split if the text before `(` looks like a plain
+                // identifier (no type operators).
+                let is_plain_ident = !before.contains('|')
+                    && !before.contains('&')
+                    && !before.contains('<')
+                    && !before.contains('{')
+                    && !before.contains(' ');
+                if is_plain_ident {
+                    ("", return_type)
+                } else {
+                    (return_type, remainder)
+                }
+            } else {
+                (return_type, remainder)
+            }
+        } else {
+            (return_type, remainder)
+        };
+
     if !return_type.is_empty() {
         emit_type_spans(
             return_type,
@@ -1155,6 +1203,28 @@ fn extract_method_tag_symbols(
 
     // After the return type, find the `(` for parameter list.
     if let Some(paren_pos) = remainder.find('(') {
+        // Emit MemberDeclaration span for the method name.
+        let method_name = remainder[..paren_pos].trim();
+        if !method_name.is_empty() {
+            // Calculate the absolute offset of the method name within the
+            // docblock.  `remainder` is a substring of `rest` that starts
+            // after `return_type`.  Its first byte is at:
+            //   rest_offset_in_docblock + return_type.len()
+            let remainder_start_in_docblock = rest_offset_in_docblock + return_type.len();
+            let trimmed_before_paren = remainder[..paren_pos].trim_start();
+            let ws_before_name = remainder[..paren_pos].len() - trimmed_before_paren.len();
+            let name_start_in_docblock = remainder_start_in_docblock + ws_before_name;
+            let name_file_start = base_offset + name_start_in_docblock as u32;
+            let name_file_end = name_file_start + method_name.len() as u32;
+            spans.push(SymbolSpan {
+                start: name_file_start,
+                end: name_file_end,
+                kind: SymbolKind::MemberDeclaration {
+                    name: method_name.to_string(),
+                    is_static,
+                },
+            });
+        }
         let close = remainder[paren_pos..].find(')');
         if let Some(close_pos) = close {
             let inner = &remainder[paren_pos + 1..paren_pos + close_pos];
@@ -1197,6 +1267,76 @@ fn extract_method_tag_symbols(
             );
         }
     }
+}
+
+// ─── @property tag symbol extraction ───────────────────────────────────────
+
+/// Extract a `MemberDeclaration` span from `@property`, `@property-read`,
+/// `@property-write`, and their `@psalm-` equivalents.
+///
+/// Format: `@property Type $name` or `@property $name` (no type).
+/// The emitted `MemberDeclaration` name does **not** include the `$` prefix.
+fn extract_property_tag_symbols(
+    docblock: &str,
+    desc_start_in_docblock: usize,
+    base_offset: u32,
+    spans: &mut Vec<SymbolSpan>,
+) {
+    if desc_start_in_docblock >= docblock.len() {
+        return;
+    }
+    let raw = &docblock[desc_start_in_docblock..];
+    let first_nl = raw.find('\n').unwrap_or(raw.len());
+    let first_line = &raw[..first_nl];
+    let trimmed = first_line.trim_start();
+    if trimmed.is_empty() {
+        return;
+    }
+    let leading_ws = first_line.len() - trimmed.len();
+    let adjusted_start = desc_start_in_docblock + leading_ws;
+
+    // Split off the type (if any).  The property name `$name` is in the
+    // remainder after the type.
+    let (type_token, remainder) = split_type_token(trimmed);
+
+    // Emit type spans for the property type (if present).
+    if !type_token.is_empty() {
+        emit_type_spans(type_token, base_offset + adjusted_start as u32, spans);
+    }
+
+    // Find `$name` in the remainder.
+    let remainder_trimmed = remainder.trim_start();
+    if remainder_trimmed.is_empty() {
+        return;
+    }
+    let Some(dollar_pos) = remainder_trimmed.find('$') else {
+        return;
+    };
+    let after_dollar = &remainder_trimmed[dollar_pos + '$'.len_utf8()..];
+    // The name ends at the next whitespace or end of string.
+    let name_end = after_dollar
+        .find(|c: char| c.is_whitespace())
+        .unwrap_or(after_dollar.len());
+    let prop_name = &after_dollar[..name_end];
+    if prop_name.is_empty() {
+        return;
+    }
+
+    // Calculate absolute offset of the property name (excluding `$`).
+    let ws_before_remainder = remainder.len() - remainder_trimmed.len();
+    let name_start_in_docblock =
+        adjusted_start + type_token.len() + ws_before_remainder + dollar_pos + '$'.len_utf8();
+    let name_file_start = base_offset + name_start_in_docblock as u32;
+    let name_file_end = name_file_start + prop_name.len() as u32;
+
+    spans.push(SymbolSpan {
+        start: name_file_start,
+        end: name_file_end,
+        kind: SymbolKind::MemberDeclaration {
+            name: prop_name.to_string(),
+            is_static: false,
+        },
+    });
 }
 
 // ─── @see tag symbol extraction ─────────────────────────────────────────────


### PR DESCRIPTION
Most existing Laravel projects are declaring properties like this (same for methods in facades)


```php

namespace App\Models;

use Carbon\Carbon;

/**
* @property int $id
* @property string $email
* @property Carbon $created_at
*/
class User extends Model
{
//...
}
```

I am used to ctrl+clicking on properties like this to find all references but phpantom did not emit `MemberDeclaration` on those spans for this (and rename action which I'm also often using in the same place)

