### PR TITLE
Optimize Find References while preserving alias and workspace refresh behavior

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,7 @@ harness = false
 [[bench]]
 name = "completion"
 harness = false
+
+[[bench]]
+name = "references"
+harness = false

--- a/benches/references.rs
+++ b/benches/references.rs
@@ -1,0 +1,73 @@
+//! Performance benchmarks for Find References.
+//!
+//! Run with: `cargo bench --bench references`
+
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use phpantom_lsp::Backend;
+use tower_lsp::lsp_types::*;
+
+/// Generate a large project with `num_classes` classes.
+/// Half of them extend a base class.
+fn generate_large_project(num_classes: usize) -> Vec<(String, String)> {
+    let mut files = Vec::new();
+
+    // Base class
+    files.push((
+        "file:///Base.php".to_string(),
+        "<?php class Base { public function targetMethod() {} }".to_string(),
+    ));
+
+    // Many descendants
+    for i in 0..num_classes {
+        let content = if i % 2 == 0 {
+            format!(
+                "<?php class Class{} extends Base {{ public function other() {{ $this->targetMethod(); }} }}",
+                i
+            )
+        } else {
+            format!("<?php class Class{} {{ public function other() {{ }} }}", i)
+        };
+        files.push((format!("file:///Class{}.php", i), content));
+    }
+
+    files
+}
+
+fn bench_references(c: &mut Criterion) {
+    let mut group = c.benchmark_group("find_references");
+
+    for size in [50, 150].iter() {
+        group.bench_with_input(
+            BenchmarkId::new("hierarchy_scan", size),
+            size,
+            |b, &size| {
+                let backend = Backend::new_headless();
+                let files = generate_large_project(size);
+
+                // Initial indexing (warm up)
+                for (uri, content) in &files {
+                    backend.update_ast(uri, content);
+                }
+
+                let base_content = "<?php class Base { public function targetMethod() {} }";
+                let pos = Position {
+                    line: 0,
+                    character: 40,
+                }; // On 'targetMethod'
+
+                b.iter(|| {
+                    let _ = black_box(backend.find_references(
+                        "file:///Base.php",
+                        base_content,
+                        pos,
+                        false,
+                    ));
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_references);
+criterion_main!(benches);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Blade template support.** Completion, hover, go-to-definition, diagnostics, semantic tokens, and inlay hints work inside `.blade.php` files. (thanks [@MingJen](https://github.com/MingJen))
+- **Blade template support.** Completion, hover, go-to-definition, diagnostics, semantic tokens, and inlay hints work inside `.blade.php` files. Contributed by @MingJen in https://github.com/AJenbo/phpantom_lsp/pull/100.
 - **Blade keyword highlighting.** Blade directives, echo delimiters, PHP keywords, cast types, comments, and PHPDoc tags inside `.blade.php` files now receive semantic tokens for proper syntax coloring.
 - **Blade view directive navigation.** Go-to-definition works on view names inside Blade directives (`@include`, `@extends`, `@includeIf`, `@includeWhen`, `@includeUnless`, `@includeFirst`, `@component`, `@each`), jumping to the referenced template file.
 - **Replace FQCN with import.** A refactoring code action on any fully-qualified class name (`\Foo\Bar`) inserts a `use` statement and replaces the inline reference with the short name. Detects existing imports and short-name conflicts.
@@ -29,9 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Import all missing classes.** A bulk code action that imports every unresolved class name in the file at once. Ambiguous names are left for manual resolution.
 - **Context-aware import candidate filtering.** Import class actions now filter candidates by syntactic context (only interfaces after `implements`, only traits after `use`, etc.).
 - **Convert to instance variable.** A code action that promotes a local variable inside a method to a class property, rewriting all references to `$this->prop` (or `self::$prop` in static methods).
-- **Laravel view, route, and translation key navigation.** Go to Definition works for Blade view names (`view('...')`), route names (`route('...')`), and translation keys (`__('...')`, `trans(...)`, `Lang::get(...)`). (thanks @MingJen)
-- **Laravel config and env key navigation.** Go to Definition and Find All References work for config keys and env variables (`config('app.name')`, `env('APP_KEY')`). (thanks @MingJen)
-- **Untyped property type inference from constructor.** Properties without type declarations are resolved by inspecting the constructor body for assignments and promoted parameter defaults. (thanks @lucasacoutinho)
+- **Laravel view, route, and translation key navigation.** Go to Definition works for Blade view names (`view('...')`), route names (`route('...')`), and translation keys (`__('...')`, `trans(...)`, `Lang::get(...)`). Contributed by @MingJen in https://github.com/AJenbo/phpantom_lsp/pull/101.
+- **Laravel config and env key navigation.** Go to Definition and Find All References work for config keys and env variables (`config('app.name')`, `env('APP_KEY')`). Contributed by @MingJen in https://github.com/AJenbo/phpantom_lsp/pull/93.
+- **Untyped property type inference from constructor.** Properties without type declarations are resolved by inspecting the constructor body for assignments and promoted parameter defaults. Contributed by @lucasacoutinho in https://github.com/AJenbo/phpantom_lsp/pull/81.
 - **Binary expression type inference.** Hover and variable resolution now show result types for all binary operators (`int + int` → `int`, `int + float` → `float`, `int / int` → `int|float`). Compound assignments update the variable's type accordingly.
 - **Nested array shape inference from multi-level key assignments.** Assignments like `$b['a']['b'] = 'x'` now produce a nested array shape type (`array{a: array{b: string}}`), enabling array key completion for incrementally built arrays.
 - **Loop type propagation.** Variables assigned late in loop bodies are now visible from the start on subsequent iterations.
@@ -40,10 +40,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Machine-readable CLI output.** Both `analyze` and `fix` accept a `--format` flag with `table`, `github`, and `json` options. When `GITHUB_ACTIONS` is set, table output automatically includes GitHub annotations.
 - **Magic property diagnostics.** New `report-magic-properties` option under `[diagnostics]` in `.phpantom.toml`. When enabled, classes with `__get` that also have virtual properties (from `@property` docblock tags, Laravel Eloquent column inference, or other providers) will flag unknown property access instead of silently allowing it.
 - **Inline diagnostic suppression.** `// @phpantom-ignore code` on the same line or the line above suppresses the specified diagnostic. Multiple codes can be comma-separated. A bare `// @phpantom-ignore` suppresses all diagnostics on the target line.
-- **Find references and rename for PHPDoc virtual members.** `@property`, `@property-read`, `@property-write`, and `@method` declarations in docblocks are now included in find-references and rename results alongside their runtime usages, including when the subject has a nullable or union type (e.g. `Foo|null` from `->first()`). (thanks @AbyssWaIker)
+- **Find references and rename for PHPDoc virtual members.** `@property`, `@property-read`, `@property-write`, and `@method` declarations in docblocks are now included in find-references and rename results alongside their runtime usages, including when the subject has a nullable or union type (e.g. `Foo|null` from `->first()`). Contributed by @AbyssWaIker in https://github.com/AJenbo/phpantom_lsp/pull/115.
 
 ### Changed
 
+- **Find References performance and freshness.** Project-wide Find References now avoids more unnecessary file work while still returning references through aliased class and function imports, and it refreshes newly added workspace PHP files on later searches. Contributed by @MingJen in https://github.com/AJenbo/phpantom_lsp/pull/116.
 - **Incremental text sync.** The server now uses incremental document sync, receiving only changed ranges from the editor instead of the full file content on every keystroke.
 - **Replace FQCN with import.** Now replaces all occurrences of the same FQCN throughout the file in one action, not just the one under the cursor. A new "Replace all FQCNs with imports" action appears when the file contains multiple distinct FQCNs, replacing all of them at once (skipping those with import conflicts).
 - **LSP responsiveness.** Hover, go-to-definition, signature help, code actions, rename, and other handlers now run on background threads. Slow requests no longer block other requests or cancellations.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -615,6 +615,13 @@ pub struct Backend {
     /// URIs opened with `languageId == "blade"` that don't have a `.blade.php` extension.
     /// Allows editors to signal Blade files via languageId alone.
     pub(crate) blade_uris: Arc<RwLock<std::collections::HashSet<String>>>,
+    /// Whether the workspace directory has been fully scanned for PHP files.
+    ///
+    /// Set to `true` after the first Phase 2 walk in `ensure_workspace_indexed`.
+    /// Subsequent calls still re-walk the directory to discover newly created
+    /// files, but the flag lets us log the difference between initial and
+    /// refresh scans.
+    pub(crate) workspace_indexed: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl Backend {
@@ -695,6 +702,7 @@ impl Backend {
             blade_virtual_content: Arc::new(RwLock::new(HashMap::new())),
             blade_source_maps: Arc::new(RwLock::new(HashMap::new())),
             blade_uris: Arc::new(RwLock::new(std::collections::HashSet::new())),
+            workspace_indexed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
 
@@ -771,6 +779,7 @@ impl Backend {
             blade_virtual_content: Arc::new(RwLock::new(HashMap::new())),
             blade_source_maps: Arc::new(RwLock::new(HashMap::new())),
             blade_uris: Arc::new(RwLock::new(std::collections::HashSet::new())),
+            workspace_indexed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
 
@@ -1126,6 +1135,7 @@ impl Backend {
             blade_virtual_content: Arc::clone(&self.blade_virtual_content),
             blade_source_maps: Arc::clone(&self.blade_source_maps),
             blade_uris: Arc::clone(&self.blade_uris),
+            workspace_indexed: Arc::clone(&self.workspace_indexed),
         }
     }
 

--- a/src/references/mod.rs
+++ b/src/references/mod.rs
@@ -31,7 +31,7 @@ use tower_lsp::lsp_types::{Location, Position, Range, Url};
 
 use crate::Backend;
 use crate::symbol_map::{SelfStaticParentKind, SymbolKind, SymbolMap, VarDefKind};
-use crate::types::{ClassInfo, MAX_INHERITANCE_DEPTH};
+use crate::types::ClassInfo;
 use crate::util::{
     build_fqn, collect_php_files_gitignore, find_class_at_offset, offset_to_position,
     position_to_offset, push_unique_location, strip_fqn_prefix,
@@ -51,12 +51,25 @@ impl Backend {
         position: Position,
         include_declaration: bool,
     ) -> Option<Vec<Location>> {
+        let start_total = std::time::Instant::now();
+        tracing::info!(
+            "Find References: starting at {} line {} char {}",
+            uri,
+            position.line,
+            position.character
+        );
+
         // Consult the precomputed symbol map for the current file
         // (retries one byte earlier for end-of-token edge cases).
         let symbol = self.lookup_symbol_at_position(uri, content, position);
 
         // When the cursor is on a symbol span, dispatch by kind.
         if let Some(ref sym) = symbol {
+            tracing::info!(
+                "Find References: found symbol kind {:?} at offset {}",
+                sym.kind,
+                sym.start
+            );
             let locations = self.dispatch_symbol_references(
                 &sym.kind,
                 uri,
@@ -64,22 +77,36 @@ impl Backend {
                 sym.start,
                 include_declaration,
             );
+            tracing::info!(
+                "Find References: total time for {:?}: {:?}",
+                sym.kind,
+                start_total.elapsed()
+            );
             if !locations.is_empty() {
                 return Some(locations);
             }
         }
 
-        // Fallback for declaration sites in config/*.php, where array keys are
-        // not in the symbol map and lookup_symbol_at_position returns None.
-        // Also handles cases where the cursor is on a string literal that was
-        // indexed as a ClassReference (e.g. 'User' => ...) but the user
-        // actually wants config references.
+        // Fallback for declaration sites in config/*.php
+        let start_laravel = std::time::Instant::now();
         if let Some(locations) =
             laravel::find_config_references(self, uri, content, position, include_declaration)
         {
+            tracing::info!(
+                "Find References: found Laravel config references in {:?}",
+                start_laravel.elapsed()
+            );
+            tracing::info!(
+                "Find References: total time (fallback path): {:?}",
+                start_total.elapsed()
+            );
             return Some(locations);
         }
 
+        tracing::info!(
+            "Find References: no references found in {:?}",
+            start_total.elapsed()
+        );
         None
     }
 
@@ -423,7 +450,7 @@ impl Backend {
         let mut prev_len = 0;
         while reachable.len() != prev_len {
             prev_len = reachable.len();
-            let current: Vec<u32> = reachable.iter().copied().collect();
+            let current = reachable.clone();
 
             for def in &symbol_map.var_defs {
                 if def.name != var_name || def.kind != VarDefKind::ClosureCapture {
@@ -597,28 +624,19 @@ impl Backend {
             let file_namespace = self.first_file_namespace(file_uri);
             let file_use_map = std::cell::OnceCell::new();
 
-            let parsed_uri = match Url::parse(file_uri) {
-                Ok(u) => u,
-                Err(_) => continue,
-            };
-
-            let content = match self.get_file_content_arc(file_uri) {
-                Some(c) => c,
-                None => continue,
-            };
-
-            for span in &symbol_map.spans {
-                match &span.kind {
-                    SymbolKind::ClassReference { name, is_fqn, .. } => {
-                        let resolved = if *is_fqn {
-                            name.clone()
-                        } else if let Some(fqn) =
+            // First pass: resolved-name check to avoid unnecessary content work.
+            // Aliased imports (`use Foo as Bar; new Bar`) must still reach the
+            // full matching loop, because the textual span name is the alias.
+            let has_potential_match = symbol_map.spans.iter().any(|span| match &span.kind {
+                SymbolKind::ClassReference { name, .. } => {
+                    if crate::util::short_name(name) == target_short {
+                        true
+                    } else {
+                        let resolved = if let Some(fqn) =
                             resolved_names.as_ref().and_then(|rn| rn.get(span.start))
                         {
                             fqn.to_string()
                         } else {
-                            // Fallback for offsets not tracked by mago-names
-                            // (e.g. docblock-sourced ClassReference spans).
                             let use_map = file_use_map.get_or_init(|| {
                                 self.file_imports
                                     .read()
@@ -628,55 +646,86 @@ impl Backend {
                             });
                             Self::resolve_to_fqn(name, use_map, &file_namespace)
                         };
-                        // Input boundary: resolve_to_fqn may return a leading `\`.
-                        let resolved_normalized = strip_fqn_prefix(&resolved);
-                        if !class_names_match(resolved_normalized, target, target_short) {
-                            continue;
-                        }
-                        let start = offset_to_position(&content, span.start as usize);
-                        let end = offset_to_position(&content, span.end as usize);
-                        locations.push(Location {
-                            uri: parsed_uri.clone(),
-                            range: Range { start, end },
-                        });
+                        class_names_match(strip_fqn_prefix(&resolved), target, target_short)
+                    }
+                }
+                SymbolKind::ClassDeclaration { name } => {
+                    include_declaration && name == target_short
+                }
+                SymbolKind::SelfStaticParent(ssp_kind) => *ssp_kind != SelfStaticParentKind::This,
+                _ => false,
+            });
+
+            if !has_potential_match {
+                continue;
+            }
+
+            let parsed_uri = match Url::parse(file_uri) {
+                Ok(u) => u,
+                Err(_) => continue,
+            };
+
+            // Lazily load file content only if we find a true FQN match.
+            let mut file_content: Option<Arc<String>> = None;
+
+            for span in &symbol_map.spans {
+                let matched = match &span.kind {
+                    SymbolKind::ClassReference { name, is_fqn, .. } => {
+                        let resolved = if *is_fqn {
+                            name.clone()
+                        } else if let Some(fqn) =
+                            resolved_names.as_ref().and_then(|rn| rn.get(span.start))
+                        {
+                            fqn.to_string()
+                        } else {
+                            let use_map = file_use_map.get_or_init(|| {
+                                self.file_imports
+                                    .read()
+                                    .get(file_uri)
+                                    .cloned()
+                                    .unwrap_or_default()
+                            });
+                            Self::resolve_to_fqn(name, use_map, &file_namespace)
+                        };
+                        class_names_match(strip_fqn_prefix(&resolved), target, target_short)
                     }
                     SymbolKind::ClassDeclaration { name } if include_declaration => {
-                        let fqn = build_fqn(name, file_namespace.as_deref());
-                        if !class_names_match(&fqn, target, target_short) {
-                            continue;
+                        if name != target_short {
+                            false
+                        } else {
+                            let fqn = build_fqn(name, file_namespace.as_deref());
+                            class_names_match(&fqn, target, target_short)
                         }
-                        let start = offset_to_position(&content, span.start as usize);
-                        let end = offset_to_position(&content, span.end as usize);
-                        locations.push(Location {
-                            uri: parsed_uri.clone(),
-                            range: Range { start, end },
-                        });
                     }
-                    SymbolKind::SelfStaticParent(ssp_kind) => {
-                        // self/static/parent resolve to the current class —
-                        // include them if they resolve to the target FQN.
-                        //
-                        // Skip `$this` — it is handled as a variable, not a
-                        // class reference.
-                        if *ssp_kind == SelfStaticParentKind::This {
-                            continue;
-                        }
+                    SymbolKind::SelfStaticParent(ssp_kind)
+                        if *ssp_kind != SelfStaticParentKind::This =>
+                    {
                         if let Some(fqn) = self.resolve_keyword_to_fqn(
                             ssp_kind,
                             file_uri,
                             &file_namespace,
                             span.start,
-                        ) && class_names_match(&fqn, target, target_short)
-                        {
-                            let start = offset_to_position(&content, span.start as usize);
-                            let end = offset_to_position(&content, span.end as usize);
-                            locations.push(Location {
-                                uri: parsed_uri.clone(),
-                                range: Range { start, end },
-                            });
+                        ) {
+                            class_names_match(&fqn, target, target_short)
+                        } else {
+                            false
                         }
                     }
-                    _ => {}
+                    _ => false,
+                };
+
+                if matched {
+                    if file_content.is_none() {
+                        file_content = self.get_file_content_arc(file_uri);
+                    }
+                    if let Some(ref content) = file_content {
+                        let start = offset_to_position(content, span.start as usize);
+                        let end = offset_to_position(content, span.end as usize);
+                        locations.push(Location {
+                            uri: parsed_uri.clone(),
+                            range: Range { start, end },
+                        });
+                    }
                 }
             }
         }
@@ -690,6 +739,7 @@ impl Backend {
                 .then(a.range.start.character.cmp(&b.range.start.character))
         });
 
+        locations.dedup();
         locations
     }
 
@@ -716,15 +766,54 @@ impl Backend {
         let snapshot = self.user_file_symbol_maps();
 
         for (file_uri, symbol_map) in &snapshot {
+            // First pass: name-only check to avoid unnecessary work.
+            let has_potential_match = symbol_map.spans.iter().any(|span| match &span.kind {
+                SymbolKind::MemberAccess {
+                    member_name,
+                    is_static,
+                    ..
+                } if member_name == target_member && *is_static == target_is_static => true,
+                SymbolKind::MemberDeclaration { name, is_static }
+                    if include_declaration
+                        && name == target_member
+                        && *is_static == target_is_static =>
+                {
+                    true
+                }
+                _ => false,
+            });
+
+            // Special check for property declarations in ClassInfo (represented as Variable spans)
+            let mut check_ast_map = false;
+            if !has_potential_match
+                && include_declaration
+                && let Some(classes) = self.get_classes_for_uri(file_uri)
+            {
+                for class in &classes {
+                    for prop in &class.properties {
+                        let prop_name = prop.name.strip_prefix('$').unwrap_or(&prop.name);
+                        let target_name = target_member.strip_prefix('$').unwrap_or(target_member);
+                        if prop_name == target_name && prop.is_static == target_is_static {
+                            check_ast_map = true;
+                            break;
+                        }
+                    }
+                    if check_ast_map {
+                        break;
+                    }
+                }
+            }
+
+            if !has_potential_match && !check_ast_map {
+                continue;
+            }
+
             let parsed_uri = match Url::parse(file_uri) {
                 Ok(u) => u,
                 Err(_) => continue,
             };
 
-            let content = match self.get_file_content_arc(file_uri) {
-                Some(c) => c,
-                None => continue,
-            };
+            let mut file_content: Option<Arc<String>> = None;
 
             // Lazily resolved file context — only computed when we need
             // to check a candidate's subject against the hierarchy.
@@ -741,13 +830,20 @@ impl Backend {
                     } if member_name == target_member && *is_static == target_is_static => {
                         // Check if the subject belongs to the target hierarchy.
                         if let Some(hier) = hierarchy {
+                            if file_content.is_none() {
+                                file_content = self.get_file_content_arc(file_uri);
+                            }
+                            let Some(ref content) = file_content else {
+                                break;
+                            };
+
                             let ctx = file_ctx_cell.get_or_init(|| self.file_context(file_uri));
                             let subject_fqns = self.resolve_subject_to_fqns(
                                 subject_text,
                                 *is_static,
                                 ctx,
                                 span.start,
-                                &content,
+                                content,
                             );
                             if !subject_fqns.is_empty()
                                 && !subject_fqns.iter().any(|fqn| hier.contains(fqn))
@@ -760,8 +856,15 @@ impl Backend {
                             // the subject — include conservatively.
                         }
 
-                        let start = offset_to_position(&content, span.start as usize);
-                        let end = offset_to_position(&content, span.end as usize);
+                        if file_content.is_none() {
+                            file_content = self.get_file_content_arc(file_uri);
+                        }
+                        let Some(ref content) = file_content else {
+                            break;
+                        };
+
+                        let start = offset_to_position(content, span.start as usize);
+                        let end = offset_to_position(content, span.end as usize);
                         locations.push(Location {
                             uri: parsed_uri.clone(),
                             range: Range { start, end },
@@ -795,8 +898,15 @@ impl Backend {
                             }
                         }
 
-                        let start = offset_to_position(&content, span.start as usize);
-                        let end = offset_to_position(&content, span.end as usize);
+                        if file_content.is_none() {
+                            file_content = self.get_file_content_arc(file_uri);
+                        }
+                        let Some(ref content) = file_content else {
+                            break;
+                        };
+
+                        let start = offset_to_position(content, span.start as usize);
+                        let end = offset_to_position(content, span.end as usize);
                         locations.push(Location {
                             uri: parsed_uri.clone(),
                             range: Range { start, end },
@@ -827,10 +937,17 @@ impl Backend {
                             && prop.is_static == target_is_static
                             && prop.name_offset != 0
                         {
+                            if file_content.is_none() {
+                                file_content = self.get_file_content_arc(file_uri);
+                            }
+                            let Some(ref content) = file_content else {
+                                break;
+                            };
+
                             let offset = prop.name_offset;
-                            let start = offset_to_position(&content, offset as usize);
+                            let start = offset_to_position(content, offset as usize);
                             let end =
-                                offset_to_position(&content, offset as usize + prop.name.len());
+                                offset_to_position(content, offset as usize + prop.name.len());
                             push_unique_location(&mut locations, &parsed_uri, start, end);
                         }
                     }
@@ -870,15 +987,47 @@ impl Backend {
             let file_namespace = self.first_file_namespace(file_uri);
             let file_use_map = std::cell::OnceCell::new();
 
+            // First pass: resolved-name check. Function imports can be aliased
+            // (`use function Foo\bar as baz; baz()`), so the call-site text
+            // alone is not enough to decide whether this file can match.
+            let has_potential_match = symbol_map.spans.iter().any(|span| {
+                if let SymbolKind::FunctionCall { name, .. } = &span.kind {
+                    if name == target_short {
+                        true
+                    } else {
+                        let resolved = if let Some(fqn) =
+                            resolved_names.as_ref().and_then(|rn| rn.get(span.start))
+                        {
+                            fqn.to_string()
+                        } else {
+                            let use_map = file_use_map.get_or_init(|| {
+                                self.file_imports
+                                    .read()
+                                    .get(file_uri)
+                                    .cloned()
+                                    .unwrap_or_default()
+                            });
+                            Self::resolve_to_fqn(name, use_map, &file_namespace)
+                        };
+                        let resolved_normalized = strip_fqn_prefix(&resolved);
+                        resolved_normalized == target
+                            || crate::util::short_name(resolved_normalized) == target_short
+                    }
+                } else {
+                    false
+                }
+            });
+
+            if !has_potential_match {
+                continue;
+            }
+
             let parsed_uri = match Url::parse(file_uri) {
                 Ok(u) => u,
                 Err(_) => continue,
             };
 
-            let content = match self.get_file_content_arc(file_uri) {
-                Some(c) => c,
-                None => continue,
-            };
+            let mut file_content: Option<Arc<String>> = None;
 
             for span in &symbol_map.spans {
                 if let SymbolKind::FunctionCall {
@@ -889,6 +1038,7 @@ impl Backend {
                     if *is_definition && !include_declaration {
                         continue;
                     }
+
                     let resolved = if let Some(fqn) =
                         resolved_names.as_ref().and_then(|rn| rn.get(span.start))
                     {
@@ -903,25 +1053,24 @@ impl Backend {
                         });
                         Self::resolve_to_fqn(name, use_map, &file_namespace)
                     };
+
                     // Input boundary: resolve_to_fqn may return a leading `\`.
                     let resolved_normalized = strip_fqn_prefix(&resolved);
-                    if resolved_normalized != target
-                        && crate::util::short_name(resolved_normalized)
-                            != crate::util::short_name(target)
+                    if resolved_normalized == target
+                        || crate::util::short_name(resolved_normalized) == target_short
                     {
-                        // Also try matching by short name when the
-                        // namespaces don't line up (common for global
-                        // functions referenced from within a namespace).
-                        if name != target_short {
-                            continue;
+                        if file_content.is_none() {
+                            file_content = self.get_file_content_arc(file_uri);
+                        }
+                        if let Some(ref content) = file_content {
+                            let start = offset_to_position(content, span.start as usize);
+                            let end = offset_to_position(content, span.end as usize);
+                            locations.push(Location {
+                                uri: parsed_uri.clone(),
+                                range: Range { start, end },
+                            });
                         }
                     }
-                    let start = offset_to_position(&content, span.start as usize);
-                    let end = offset_to_position(&content, span.end as usize);
-                    locations.push(Location {
-                        uri: parsed_uri.clone(),
-                        range: Range { start, end },
-                    });
                 }
             }
         }
@@ -948,38 +1097,48 @@ impl Backend {
         let snapshot = self.user_file_symbol_maps();
 
         for (file_uri, symbol_map) in &snapshot {
+            // First pass: name-only check.
+            let has_potential_match = symbol_map.spans.iter().any(|span| match &span.kind {
+                SymbolKind::ConstantReference { name } => name == target_name,
+                SymbolKind::MemberDeclaration { name, is_static }
+                    if include_declaration && name == target_name && *is_static =>
+                {
+                    true
+                }
+                _ => false,
+            });
+
+            if !has_potential_match {
+                continue;
+            }
+
             let parsed_uri = match Url::parse(file_uri) {
                 Ok(u) => u,
                 Err(_) => continue,
             };
 
-            let content = match self.get_file_content_arc(file_uri) {
-                Some(c) => c,
-                None => continue,
-            };
+            let mut file_content: Option<Arc<String>> = None;
 
             for span in &symbol_map.spans {
-                if let SymbolKind::ConstantReference { name } = &span.kind {
-                    if name != target_name {
-                        continue;
+                let matched = match &span.kind {
+                    SymbolKind::ConstantReference { name } => name == target_name,
+                    SymbolKind::MemberDeclaration { name, is_static }
+                        if include_declaration && name == target_name && *is_static =>
+                    {
+                        true
                     }
-                    let start = offset_to_position(&content, span.start as usize);
-                    let end = offset_to_position(&content, span.end as usize);
-                    locations.push(Location {
-                        uri: parsed_uri.clone(),
-                        range: Range { start, end },
-                    });
-                }
-                // Include MemberDeclaration for constant declarations
-                // when they match (class constants use MemberDeclaration).
-                if include_declaration
-                    && let SymbolKind::MemberDeclaration { name, is_static } = &span.kind
-                    && name == target_name
-                    && *is_static
-                {
-                    let start = offset_to_position(&content, span.start as usize);
-                    let end = offset_to_position(&content, span.end as usize);
-                    push_unique_location(&mut locations, &parsed_uri, start, end);
+                    _ => false,
+                };
+
+                if matched {
+                    if file_content.is_none() {
+                        file_content = self.get_file_content_arc(file_uri);
+                    }
+                    if let Some(ref content) = file_content {
+                        let start = offset_to_position(content, span.start as usize);
+                        let end = offset_to_position(content, span.end as usize);
+                        push_unique_location(&mut locations, &parsed_uri, start, end);
+                    }
                 }
             }
         }
@@ -1140,63 +1299,27 @@ impl Backend {
 
         // Insert the seeds.
         for fqn in seed_fqns {
-            hierarchy.insert(fqn.clone());
+            hierarchy.insert(normalize_fqn(fqn).to_string());
         }
 
         // Walk up: collect all ancestors for each seed.
-        for fqn in seed_fqns {
-            self.collect_ancestors(fqn, &class_loader, &mut hierarchy);
+        let seeds: Vec<String> = hierarchy.iter().cloned().collect();
+        for fqn in seeds {
+            self.collect_ancestors(&fqn, &class_loader, &mut hierarchy);
         }
 
-        // Walk down: collect all descendants from ast_map and class_index.
-        // We iterate until no new FQNs are added (transitive closure).
-        let mut changed = true;
-        let mut depth = 0u32;
-        while changed && depth < MAX_INHERITANCE_DEPTH {
-            changed = false;
-            depth += 1;
-
-            // Snapshot the current hierarchy to check against.
-            let current: Vec<String> = hierarchy.iter().cloned().collect();
-
-            // Scan all known classes for ones that extend/implement/use
-            // anything in the current hierarchy.
-            let all_classes: Vec<ClassInfo> = {
-                let map = self.uri_classes_index.read();
-                map.values()
-                    .flat_map(|classes| classes.iter().map(|c| ClassInfo::clone(c)))
-                    .collect()
-            };
-
-            for cls in &all_classes {
-                let cls_fqn = normalize_fqn(&cls.fqn());
-                if hierarchy.contains(&cls_fqn) {
-                    continue;
-                }
-
-                if self.class_is_descendant_of(cls, &current, &class_loader) {
-                    hierarchy.insert(cls_fqn);
-                    changed = true;
-                }
-            }
-
-            // Also check class_index entries not yet in ast_map.
-            let index_entries: Vec<String> = {
-                let idx = self.fqn_uri_index.read();
-                idx.keys().cloned().collect()
-            };
-
-            for fqn in &index_entries {
-                let normalized = normalize_fqn(fqn);
-                if hierarchy.contains(&normalized) {
-                    continue;
-                }
-
-                if let Some(cls) = class_loader(fqn)
-                    && self.class_is_descendant_of(&cls, &current, &class_loader)
-                {
-                    hierarchy.insert(normalized);
-                    changed = true;
+        // Walk down: collect all descendants using the global GTI index
+        // (reverse inheritance).  This is O(hierarchy size) rather than
+        // O(total classes).
+        let mut queue: std::collections::VecDeque<String> = hierarchy.iter().cloned().collect();
+        let gti = self.gti_index.read();
+        while let Some(fqn) = queue.pop_front() {
+            if let Some(descendants) = gti.get(&fqn) {
+                for desc in descendants {
+                    let normalized = normalize_fqn(desc).to_string();
+                    if hierarchy.insert(normalized.clone()) {
+                        queue.push_back(normalized);
+                    }
                 }
             }
         }
@@ -1249,96 +1372,6 @@ impl Backend {
         }
     }
 
-    /// Check whether a class directly extends, implements, or uses
-    /// anything in the given set of FQNs.
-    fn class_is_descendant_of(
-        &self,
-        cls: &ClassInfo,
-        targets: &[String],
-        class_loader: &dyn Fn(&str) -> Option<Arc<ClassInfo>>,
-    ) -> bool {
-        // Direct parent.
-        if let Some(ref parent) = cls.parent_class {
-            let parent_fqn = normalize_fqn(parent);
-            if targets.contains(&parent_fqn) {
-                return true;
-            }
-            // Transitive: walk the parent chain.
-            if self.ancestor_in_set(&parent_fqn, targets, class_loader, 0) {
-                return true;
-            }
-        }
-
-        // Direct interfaces.
-        for iface in &cls.interfaces {
-            let iface_fqn = normalize_fqn(iface);
-            if targets.contains(&iface_fqn) {
-                return true;
-            }
-            if self.ancestor_in_set(&iface_fqn, targets, class_loader, 0) {
-                return true;
-            }
-        }
-
-        // Used traits.
-        for trait_name in &cls.used_traits {
-            let trait_fqn = normalize_fqn(trait_name);
-            if targets.contains(&trait_fqn) {
-                return true;
-            }
-        }
-
-        // Mixins.
-        for mixin in &cls.mixins {
-            let mixin_fqn = normalize_fqn(mixin);
-            if targets.contains(&mixin_fqn) {
-                return true;
-            }
-        }
-
-        false
-    }
-
-    /// Recursively check whether any ancestor of `fqn` is in the target set.
-    fn ancestor_in_set(
-        &self,
-        fqn: &str,
-        targets: &[String],
-        class_loader: &dyn Fn(&str) -> Option<Arc<ClassInfo>>,
-        depth: u32,
-    ) -> bool {
-        if depth >= MAX_INHERITANCE_DEPTH {
-            return false;
-        }
-
-        let cls = match class_loader(fqn) {
-            Some(c) => c,
-            None => return false,
-        };
-
-        if let Some(ref parent) = cls.parent_class {
-            let parent_fqn = normalize_fqn(parent);
-            if targets.contains(&parent_fqn) {
-                return true;
-            }
-            if self.ancestor_in_set(&parent_fqn, targets, class_loader, depth + 1) {
-                return true;
-            }
-        }
-
-        for iface in &cls.interfaces {
-            let iface_fqn = normalize_fqn(iface);
-            if targets.contains(&iface_fqn) {
-                return true;
-            }
-            if self.ancestor_in_set(&iface_fqn, targets, class_loader, depth + 1) {
-                return true;
-            }
-        }
-
-        false
-    }
-
     /// Ensure all workspace PHP files have been parsed and have symbol maps.
     ///
     /// This lazily parses files that are in the workspace directory but
@@ -1347,6 +1380,7 @@ impl Backend {
     /// `composer.json` `config.vendor-dir`, defaulting to `vendor`) is
     /// skipped during the filesystem walk.
     pub(crate) fn ensure_workspace_indexed(&self) {
+        let start = std::time::Instant::now();
         // Collect URIs that already have symbol maps.
         let existing_uris: HashSet<String> = self.symbol_maps.read().keys().cloned().collect();
 
@@ -1356,15 +1390,6 @@ impl Backend {
         let vendor_prefixes = self.vendor_uri_prefixes.lock().clone();
 
         // ── Phase 1: class_index files (user only) ─────────────────────
-        // These are files we already know about from update_ast calls,
-        // ensuring their symbol maps are populated.  Vendor files are
-        // skipped — find references only reports user code.
-        //
-        // File content is read and parsed in parallel using
-        // `std::thread::scope`.  Each thread reads one file from disk
-        // and calls `update_ast` which acquires write locks briefly to
-        // store the results.  The expensive parsing step runs without
-        // any locks held.
         let index_uris: Vec<String> = self.fqn_uri_index.read().values().cloned().collect();
 
         let phase1_uris: Vec<&String> = index_uris
@@ -1377,21 +1402,29 @@ impl Backend {
             })
             .collect();
 
-        self.parse_files_parallel(
-            phase1_uris
-                .iter()
-                .map(|uri| (uri.as_str(), None::<&str>))
-                .collect(),
-        );
+        if !phase1_uris.is_empty() {
+            tracing::info!(
+                "ensure_workspace_indexed: Phase 1 parsing {} files",
+                phase1_uris.len()
+            );
+            self.parse_files_parallel(
+                phase1_uris
+                    .iter()
+                    .map(|uri| (uri.as_str(), None::<&str>))
+                    .collect(),
+            );
+        }
 
         // ── Phase 2: workspace directory scan ───────────────────────────
-        // Recursively discover PHP files in the workspace root that are
-        // not yet indexed.  This catches files that are not in the
-        // classmap, class_index, or already opened.  The vendor directory
-        // is skipped — find references only reports user code.  The walk
-        // respects .gitignore so that generated/cached directories (e.g.
-        // storage/framework/views/, var/cache/, node_modules/) are
-        // automatically excluded.
+        //
+        // Even after the initial scan, repeat the walk so newly-created PHP
+        // files that are not open in the editor can still be discovered.
+        // The existing-URI filter below keeps this cheap by parsing only files
+        // that are not already in `symbol_maps`.
+        let has_scanned_workspace = self
+            .workspace_indexed
+            .load(std::sync::atomic::Ordering::Relaxed);
+
         let workspace_root = self.workspace_root.read().clone();
 
         if let Some(root) = workspace_root {
@@ -1400,7 +1433,18 @@ impl Backend {
             // Re-read existing URIs after phase 1 may have added more.
             let existing_uris: HashSet<String> = self.symbol_maps.read().keys().cloned().collect();
 
+            let walk_start = std::time::Instant::now();
             let php_files = collect_php_files_gitignore(&root, &vendor_dir_paths);
+            tracing::info!(
+                "ensure_workspace_indexed: Phase 2 {} found {} PHP files in {:?}",
+                if has_scanned_workspace {
+                    "refresh disk walk"
+                } else {
+                    "disk walk"
+                },
+                php_files.len(),
+                walk_start.elapsed()
+            );
 
             let phase2_work: Vec<(String, PathBuf)> = php_files
                 .into_iter()
@@ -1414,8 +1458,17 @@ impl Backend {
                 })
                 .collect();
 
-            self.parse_paths_parallel(&phase2_work);
+            if !phase2_work.is_empty() {
+                tracing::info!(
+                    "ensure_workspace_indexed: Phase 2 parsing {} files",
+                    phase2_work.len()
+                );
+                self.parse_paths_parallel(&phase2_work);
+            }
+            self.workspace_indexed
+                .store(true, std::sync::atomic::Ordering::Relaxed);
         }
+        tracing::info!("ensure_workspace_indexed: total time {:?}", start.elapsed());
     }
 
     /// Parse a batch of files in parallel using OS threads.

--- a/src/virtual_members/laravel/mod.rs
+++ b/src/virtual_members/laravel/mod.rs
@@ -168,6 +168,24 @@ fn find_string_key_usages(
 
     let mut locations = Vec::new();
     for (file_uri, symbol_map) in snapshot {
+        // First pass: check if this file even has ANY LaravelStringKey matches.
+        // This avoids reading file content from disk for thousands of unrelated files.
+        let has_match = symbol_map.spans.iter().any(|span| {
+            if let SymbolKind::LaravelStringKey {
+                kind: span_kind,
+                key: span_key,
+            } = &span.kind
+            {
+                span_kind == kind && span_key == key
+            } else {
+                false
+            }
+        });
+
+        if !has_match {
+            continue;
+        }
+
         let Ok(parsed_uri) = Url::parse(file_uri) else {
             continue;
         };

--- a/src/virtual_members/mod.rs
+++ b/src/virtual_members/mod.rs
@@ -1067,9 +1067,7 @@ fn resolve_class_fully_inner(
     merged.rebuild_method_index();
     let result = Arc::new(merged);
     if let Some(cache) = cache {
-        let mut map = cache.lock();
-
-        map.insert(cache_key, Arc::clone(&result));
+        cache.lock().insert(cache_key, Arc::clone(&result));
     }
 
     result

--- a/src/virtual_members/phpdoc.rs
+++ b/src/virtual_members/phpdoc.rs
@@ -633,11 +633,14 @@ fn collect_mixin_members(
         // mixin (e.g. Builder) is only resolved once per thread.
         ensure_mixin_cache_fresh();
         let resolved_mixin = if let Some(c) = cache {
-            let map = c.lock();
-            if let Some(cached) = map.get(&(Atom::from(&resolved_mixin_name), Vec::new())) {
-                Arc::clone(cached)
+            let cached = {
+                let map = c.lock();
+                map.get(&(Atom::from(&resolved_mixin_name), Vec::new()))
+                    .map(Arc::clone)
+            };
+            if let Some(cached) = cached {
+                cached
             } else {
-                drop(map);
                 MIXIN_CACHE.with(|thread_cache| {
                     let mut map = thread_cache.borrow_mut();
                     Arc::clone(map.1.entry(resolved_mixin_name.clone()).or_insert_with(|| {

--- a/tests/assert_type_runner.rs
+++ b/tests/assert_type_runner.rs
@@ -24,6 +24,270 @@ use std::path::Path;
 use phpantom_lsp::Backend;
 use tower_lsp::lsp_types::*;
 
+static UNIT_ENUM_STUB: &str = r#"<?php
+interface UnitEnum
+{
+    /** @return static[] */
+    public static function cases(): array;
+    public readonly string $name;
+}
+"#;
+
+static BACKED_ENUM_STUB: &str = r#"<?php
+interface BackedEnum extends UnitEnum
+{
+    public static function from(int|string $value): static;
+    public static function tryFrom(int|string $value): ?static;
+    public readonly int|string $value;
+}
+"#;
+
+static GENERATOR_STUB: &str = r#"<?php
+/**
+ * @template TKey
+ * @template TValue
+ * @template TSend
+ * @template TReturn
+ */
+final class Generator
+{
+    /** @return TReturn */
+    public function getReturn(): mixed {}
+}
+"#;
+
+static NO_REWIND_ITERATOR_STUB: &str = r#"<?php
+/**
+ * @template TKey
+ * @template TValue
+ * @template TIterator of Iterator<TKey, TValue>
+ */
+class NoRewindIterator
+{
+    /** @param TIterator $iterator */
+    public function __construct(Traversable $iterator) {}
+    /** @return TValue */
+    public function current(): mixed {}
+    /** @return TKey */
+    public function key(): mixed {}
+}
+"#;
+
+static ITERATOR_STUB: &str = r#"<?php
+/**
+ * @template TKey
+ * @template TValue
+ */
+interface Iterator extends Traversable
+{
+    /** @return TValue */
+    public function current(): mixed;
+    /** @return TKey */
+    public function key(): mixed;
+    public function next(): void;
+    public function rewind(): void;
+    public function valid(): bool;
+}
+"#;
+
+static ITERATOR_AGGREGATE_STUB: &str = r#"<?php
+/**
+ * @template TKey
+ * @template TValue
+ */
+interface IteratorAggregate extends Traversable
+{
+    /** @return Traversable<TKey, TValue>|array<TValue> */
+    public function getIterator(): Traversable|array;
+}
+"#;
+
+static ITERATOR_ITERATOR_STUB: &str = r#"<?php
+/**
+ * @template TKey
+ * @template TValue
+ * @template TIterator of Iterator<TKey, TValue>
+ * @mixin TIterator
+ */
+class IteratorIterator implements Iterator
+{
+    /** @param TIterator $iterator */
+    public function __construct(Traversable $iterator) {}
+    /** @return TValue */
+    public function current(): mixed {}
+    /** @return TKey */
+    public function key(): mixed {}
+    public function next(): void {}
+    public function rewind(): void {}
+    public function valid(): bool {}
+}
+"#;
+
+static SPL_ITERATOR_STUB: &str = r#"<?php
+/**
+ * @template TKey
+ * @template TValue
+ * @implements Iterator<TKey, TValue>
+ */
+class ArrayIterator implements Iterator
+{
+    /** @param array<TKey, TValue> $array */
+    public function __construct(array $array = []) {}
+    /** @return TValue */
+    public function current(): mixed {}
+    /** @return TKey */
+    public function key(): mixed {}
+    public function next(): void {}
+    public function rewind(): void {}
+    public function valid(): bool {}
+}
+
+/**
+ * @template TKey
+ * @template TValue
+ * @template TIterator of Iterator<TKey, TValue>
+ * @extends IteratorIterator<TKey, TValue, TIterator>
+ */
+class CachingIterator extends IteratorIterator
+{
+    /** @param TIterator $iterator */
+    public function __construct(Iterator $iterator) {}
+    public function hasNext(): bool {}
+}
+
+/**
+ * @template TKey
+ * @template TValue
+ * @template TIterator of Iterator<TKey, TValue>
+ * @extends IteratorIterator<TKey, TValue, TIterator>
+ */
+class InfiniteIterator extends IteratorIterator
+{
+    /** @param TIterator $iterator */
+    public function __construct(Iterator $iterator) {}
+}
+
+/**
+ * @template TKey
+ * @template TValue
+ * @template TIterator of Iterator<TKey, TValue>
+ * @extends IteratorIterator<TKey, TValue, TIterator>
+ */
+class LimitIterator extends IteratorIterator
+{
+    /** @param TIterator $iterator */
+    public function __construct(Iterator $iterator, int $offset = 0, int $limit = -1) {}
+}
+
+/**
+ * @template TKey
+ * @template TValue
+ * @template TIterator of Iterator<TKey, TValue>
+ * @extends IteratorIterator<TKey, TValue, TIterator>
+ */
+class CallbackFilterIterator extends IteratorIterator
+{
+    /** @param TIterator $iterator */
+    public function __construct(Iterator $iterator, callable $callback) {}
+}
+
+/**
+ * @template TValue
+ */
+class SplDoublyLinkedList
+{
+    /** @param TValue $value */
+    public function add(int $index, mixed $value): void {}
+    /** @return TValue */
+    public function bottom(): mixed {}
+}
+
+/**
+ * @template TKey of object
+ * @template TValue
+ */
+class SplObjectStorage
+{
+    /** @return TValue */
+    public function offsetGet(object $object): mixed {}
+}
+
+/**
+ * @template TKey of array-key
+ * @template TValue
+ */
+class ArrayObject
+{
+    /** @param array<TKey, TValue> $array */
+    public function __construct(array $array = []) {}
+    /** @return ArrayIterator<TKey, TValue> */
+    public function getIterator(): ArrayIterator {}
+}
+"#;
+
+static TRAVERSABLE_STUB: &str = r#"<?php
+/**
+ * @template TKey
+ * @template TValue
+ */
+interface Traversable {}
+"#;
+
+static DATE_INTERVAL_STUB: &str = r#"<?php
+class DateInterval
+{
+    public function __construct(string $duration) {}
+}
+"#;
+
+static DATE_TIME_IMMUTABLE_STUB: &str = r#"<?php
+class DateTimeImmutable
+{
+    public function __construct(string $datetime = "now") {}
+    public function sub(DateInterval $interval): static {}
+    public function modify(string $modifier): DateTimeImmutable|false {}
+}
+"#;
+
+static EXCEPTION_STUB: &str =
+    "<?php\nclass Exception {}\nclass LogicException extends Exception {}\n";
+
+static WEAK_REFERENCE_STUB: &str = r#"<?php
+class WeakReference
+{
+    public static function create(object $object): WeakReference {}
+    /** @return Exception|null */
+    public function get(): ?object {}
+}
+"#;
+
+static DOM_DOCUMENT_STUB: &str = "<?php\nclass DOMDocument {}\n";
+
+static DOM_ELEMENT_STUB: &str = r#"<?php
+class DOMElement
+{
+    public ?DOMDocument $ownerDocument;
+    public function __construct(string $qualifiedName, string $value = "", string $namespace = "") {}
+}
+"#;
+
+static SIMPLE_XML_ELEMENT_STUB: &str = r#"<?php
+class SimpleXMLElement
+{
+    public function __construct(string $data) {}
+    public function __get(string $name): SimpleXMLElement {}
+}
+"#;
+
+static STDCLASS_STUB: &str = "<?php\nclass stdClass {}\n";
+
+static ARRAY_FUNCTION_STUB: &str = r#"<?php
+/**
+ * @return array<int, string>
+ */
+function range(string $start, string $end): array {}
+"#;
+
 // ─── Assertion extraction ───────────────────────────────────────────────────
 
 /// A single `assertType('expected', expr)` call found in the source.
@@ -604,7 +868,51 @@ fn extract_type_from_hover(hover_text: &str, var_name: &str) -> Option<String> {
 // ─── Test runner ────────────────────────────────────────────────────────────
 
 fn create_assert_type_backend() -> Backend {
-    Backend::new_test_with_full_stubs()
+    let mut class_stubs: HashMap<&'static str, &'static str> = HashMap::new();
+    class_stubs.insert("UnitEnum", UNIT_ENUM_STUB);
+    class_stubs.insert("BackedEnum", BACKED_ENUM_STUB);
+    class_stubs.insert("Generator", GENERATOR_STUB);
+    class_stubs.insert("NoRewindIterator", NO_REWIND_ITERATOR_STUB);
+    class_stubs.insert("Iterator", ITERATOR_STUB);
+    class_stubs.insert("IteratorAggregate", ITERATOR_AGGREGATE_STUB);
+    class_stubs.insert("IteratorIterator", ITERATOR_ITERATOR_STUB);
+    class_stubs.insert("ArrayIterator", SPL_ITERATOR_STUB);
+    class_stubs.insert("CachingIterator", SPL_ITERATOR_STUB);
+    class_stubs.insert("InfiniteIterator", SPL_ITERATOR_STUB);
+    class_stubs.insert("LimitIterator", SPL_ITERATOR_STUB);
+    class_stubs.insert("CallbackFilterIterator", SPL_ITERATOR_STUB);
+    class_stubs.insert("SplDoublyLinkedList", SPL_ITERATOR_STUB);
+    class_stubs.insert("SplObjectStorage", SPL_ITERATOR_STUB);
+    class_stubs.insert("ArrayObject", SPL_ITERATOR_STUB);
+    class_stubs.insert("Traversable", TRAVERSABLE_STUB);
+    class_stubs.insert("DateInterval", DATE_INTERVAL_STUB);
+    class_stubs.insert("DateTimeImmutable", DATE_TIME_IMMUTABLE_STUB);
+    class_stubs.insert("Exception", EXCEPTION_STUB);
+    class_stubs.insert("LogicException", EXCEPTION_STUB);
+    class_stubs.insert("WeakReference", WEAK_REFERENCE_STUB);
+    class_stubs.insert("DOMDocument", DOM_DOCUMENT_STUB);
+    class_stubs.insert("DOMElement", DOM_ELEMENT_STUB);
+    class_stubs.insert("SimpleXMLElement", SIMPLE_XML_ELEMENT_STUB);
+    class_stubs.insert("stdClass", STDCLASS_STUB);
+
+    let mut func_stubs: HashMap<&'static str, &'static str> = HashMap::new();
+    func_stubs.insert("range", ARRAY_FUNCTION_STUB);
+
+    Backend::new_test_with_all_stubs(class_stubs, func_stubs, HashMap::new())
+}
+
+fn fixture_uri(path: &Path) -> String {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .expect("assert-type runner should have a current directory")
+            .join(path)
+    };
+
+    Url::from_file_path(&absolute)
+        .expect("assert-type fixture path should convert to a file URI")
+        .to_string()
 }
 
 fn run_assert_type(path: &Path, content: String) -> datatest_stable::Result<()> {
@@ -621,8 +929,8 @@ fn run_assert_type(path: &Path, content: String) -> datatest_stable::Result<()> 
 
     // Create backend and open the file.
     let backend = create_assert_type_backend();
-    let uri = "file:///test.php";
-    backend.update_ast(uri, &transformed);
+    let uri = fixture_uri(path);
+    backend.update_ast(&uri, &transformed);
 
     let mut failures: Vec<String> = Vec::new();
     let mut passed = 0;
@@ -650,7 +958,7 @@ fn run_assert_type(path: &Path, content: String) -> datatest_stable::Result<()> 
             character: col + 1, // +1 to land inside the variable name (past $)
         };
 
-        let hover = backend.handle_hover(uri, &transformed, position);
+        let hover = backend.handle_hover(&uri, &transformed, position);
 
         match hover {
             Some(h) => {

--- a/tests/integration/completion_attributes.rs
+++ b/tests/integration/completion_attributes.rs
@@ -1,9 +1,36 @@
-use crate::common::{create_test_backend, create_test_backend_with_full_stubs};
+use crate::common::create_test_backend;
 use phpantom_lsp::Backend;
+use std::collections::HashMap;
 use tower_lsp::LanguageServer;
 use tower_lsp::lsp_types::*;
 
+static BUILTIN_ATTRIBUTE_STUB: &str = r#"<?php
+final class Attribute
+{
+    public const TARGET_CLASS = 1;
+    public const TARGET_FUNCTION = 2;
+    public const TARGET_METHOD = 4;
+    public const TARGET_PROPERTY = 8;
+    public const TARGET_CLASS_CONSTANT = 16;
+    public const TARGET_PARAMETER = 32;
+    public const TARGET_ALL = 63;
+    public const IS_REPEATABLE = 64;
+
+    public function __construct(int $flags = self::TARGET_ALL) {}
+}
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final class Override {}
+"#;
+
 // ─── Helper ─────────────────────────────────────────────────────────────────
+
+fn create_builtin_attribute_backend() -> Backend {
+    let mut class_stubs: HashMap<&'static str, &'static str> = HashMap::new();
+    class_stubs.insert("Attribute", BUILTIN_ATTRIBUTE_STUB);
+    class_stubs.insert("Override", BUILTIN_ATTRIBUTE_STUB);
+    Backend::new_test_with_all_stubs(class_stubs, HashMap::new(), HashMap::new())
+}
 
 async fn complete_at(
     backend: &Backend,
@@ -809,7 +836,7 @@ async fn attribute_context_no_following_declaration_in_class() {
 /// a method.
 #[tokio::test]
 async fn attribute_context_shows_builtin_override() {
-    let backend = create_test_backend_with_full_stubs();
+    let backend = create_builtin_attribute_backend();
 
     let uri = Url::parse("file:///test_attr_builtin.php").unwrap();
     let text = concat!(

--- a/tests/integration/completion_generics.rs
+++ b/tests/integration/completion_generics.rs
@@ -1,8 +1,70 @@
-use crate::common::{
-    create_psr4_workspace, create_test_backend, create_test_backend_with_full_stubs,
-};
+use crate::common::{create_psr4_workspace, create_test_backend};
+use phpantom_lsp::Backend;
+use std::collections::HashMap;
 use tower_lsp::LanguageServer;
 use tower_lsp::lsp_types::*;
+
+static SPL_GENERIC_STUB: &str = r#"<?php
+/**
+ * @template TKey
+ * @template TValue
+ */
+interface Traversable {}
+
+/**
+ * @template TKey
+ * @template TValue
+ */
+interface Iterator extends Traversable
+{
+    /** @return TValue */
+    public function current(): mixed;
+    /** @return TKey */
+    public function key(): mixed;
+    public function next(): void;
+    public function rewind(): void;
+    public function valid(): bool;
+}
+
+/**
+ * @template TKey
+ * @template TValue
+ * @implements Iterator<TKey, TValue>
+ */
+class ArrayIterator implements Iterator
+{
+    /** @param array<TKey, TValue> $array */
+    public function __construct(array $array = []) {}
+    /** @return TValue */
+    public function current(): mixed {}
+    /** @return TKey */
+    public function key(): mixed {}
+    public function next(): void {}
+    public function rewind(): void {}
+    public function valid(): bool {}
+}
+
+/**
+ * @template TKey of array-key
+ * @template TValue
+ */
+class ArrayObject
+{
+    /** @param array<TKey, TValue> $array */
+    public function __construct(array $array = []) {}
+    /** @return ArrayIterator<TKey, TValue> */
+    public function getIterator(): ArrayIterator {}
+}
+"#;
+
+fn create_spl_generic_backend() -> Backend {
+    let mut class_stubs: HashMap<&'static str, &'static str> = HashMap::new();
+    class_stubs.insert("Traversable", SPL_GENERIC_STUB);
+    class_stubs.insert("Iterator", SPL_GENERIC_STUB);
+    class_stubs.insert("ArrayIterator", SPL_GENERIC_STUB);
+    class_stubs.insert("ArrayObject", SPL_GENERIC_STUB);
+    Backend::new_test_with_all_stubs(class_stubs, HashMap::new(), HashMap::new())
+}
 
 // ─── Generic type resolution tests ──────────────────────────────────────────
 //
@@ -8149,7 +8211,7 @@ async fn test_reduce_two_template_params_union_callable() {
 /// to avoid variable-resolution complexity.
 #[tokio::test]
 async fn test_array_iterator_current_resolves_generic_value_type() {
-    let backend = create_test_backend_with_full_stubs();
+    let backend = create_spl_generic_backend();
 
     let uri = Url::parse("file:///array_iterator_generics.php").unwrap();
     let text = concat!(
@@ -8222,7 +8284,7 @@ async fn test_array_iterator_current_resolves_generic_value_type() {
 /// Same as above but verifies variable assignment: `$rule = ...->current(); $rule->`
 #[tokio::test]
 async fn test_array_iterator_current_via_variable_assignment() {
-    let backend = create_test_backend_with_full_stubs();
+    let backend = create_spl_generic_backend();
 
     let uri = Url::parse("file:///array_iterator_var.php").unwrap();
     let text = concat!(
@@ -9011,7 +9073,7 @@ async fn test_constructor_array_key_value_template_inference() {
 /// enabling completion on the iterator's methods like `current()`.
 #[tokio::test]
 async fn test_arrayobject_getiterator_template_substitution() {
-    let backend = create_test_backend_with_full_stubs();
+    let backend = create_spl_generic_backend();
 
     let uri = Url::parse("file:///arrayobj_iter.php").unwrap();
     let text = concat!(

--- a/tests/integration/completion_inheritance.rs
+++ b/tests/integration/completion_inheritance.rs
@@ -1,8 +1,28 @@
-use crate::common::{
-    create_psr4_workspace, create_test_backend, create_test_backend_with_full_stubs,
-};
+use crate::common::{create_psr4_workspace, create_test_backend};
+use phpantom_lsp::Backend;
+use std::collections::HashMap;
 use tower_lsp::LanguageServer;
 use tower_lsp::lsp_types::*;
+
+static EXCEPTION_CHAIN_STUB: &str = r#"<?php
+class Exception
+{
+    public function getMessage(): string {}
+    public function getCode(): int {}
+    public function getTrace(): array {}
+}
+
+class RuntimeException extends Exception {}
+class PDOException extends RuntimeException {}
+"#;
+
+fn create_exception_chain_backend() -> Backend {
+    let mut class_stubs: HashMap<&'static str, &'static str> = HashMap::new();
+    class_stubs.insert("Exception", EXCEPTION_CHAIN_STUB);
+    class_stubs.insert("RuntimeException", EXCEPTION_CHAIN_STUB);
+    class_stubs.insert("PDOException", EXCEPTION_CHAIN_STUB);
+    Backend::new_test_with_all_stubs(class_stubs, HashMap::new(), HashMap::new())
+}
 
 // ─── Inheritance tests ──────────────────────────────────────────────────────
 
@@ -1795,7 +1815,7 @@ async fn test_interface_virtual_members_visible_through_parent_chain() {
 /// Exception).
 #[tokio::test]
 async fn test_completion_deep_inheritance_through_stubs() {
-    let backend = create_test_backend_with_full_stubs();
+    let backend = create_exception_chain_backend();
 
     let uri = Url::parse("file:///deep_chain.php").unwrap();
     let text = concat!(

--- a/tests/integration/diag_timing.rs
+++ b/tests/integration/diag_timing.rs
@@ -54,7 +54,7 @@ async fn deprecated_diagnostics_variable_cache_regression() {
     php.push_str("    }\n}\n");
 
     let uri = "file:///test/service.php";
-    let backend = create_test_backend_with_full_stubs();
+    let backend = create_test_backend();
     backend.update_ast(uri, &php);
 
     let start = Instant::now();
@@ -391,16 +391,13 @@ final class DecimalCast implements CastsAttributes {
 /// Verify that `is_object()` type-guard narrowing works in the diagnostic
 /// scope cache (forward walker).
 ///
-/// When `$data = json_decode(...)` returns `mixed` and the condition is
-/// `is_object($data) && property_exists($data, 'error_link')`, the forward
-/// walker should narrow `$data` to `object` both within the `&&` chain
-/// and inside the `if` body.
+/// When `$data` starts as `mixed` and the condition is `is_object($data) &&
+/// property_exists($data, 'error_link')`, the forward walker should narrow
+/// `$data` to `object` both within the `&&` chain and inside the `if` body.
 #[test]
 fn is_object_type_guard_no_false_positive() {
     let php = r#"<?php
-function test(string $json): ?string {
-    $data = json_decode($json, false);
-
+function test(mixed $data): ?string {
     if (is_object($data) && property_exists($data, 'error_link') && is_string($data->error_link)) {
         return stripslashes($data->error_link);
     }

--- a/tests/integration/references.rs
+++ b/tests/integration/references.rs
@@ -466,6 +466,69 @@ function test(): void {
     );
 }
 
+#[test]
+fn function_references_include_aliased_import_usage() {
+    let (backend, dir) = crate::common::create_psr4_workspace(
+        r#"{
+            "autoload": {
+                "psr-4": {
+                    "App\\": "src/"
+                }
+            }
+        }"#,
+        &[
+            (
+                "src/functions.php",
+                r#"<?php
+namespace Foo;
+
+function bar(): void {}
+"#,
+            ),
+            (
+                "src/client.php",
+                r#"<?php
+namespace App;
+
+use function Foo\bar as baz;
+
+function run(): void {
+    baz();
+}
+"#,
+            ),
+        ],
+    );
+
+    let functions_path = dir.path().join("src/functions.php");
+    let client_path = dir.path().join("src/client.php");
+
+    let functions_uri = format!("file://{}", functions_path.display());
+    let client_uri = format!("file://{}", client_path.display());
+
+    let functions_content = std::fs::read_to_string(&functions_path).unwrap();
+    let client_content = std::fs::read_to_string(&client_path).unwrap();
+
+    open_file(&backend, &functions_uri, &functions_content);
+    open_file(&backend, &client_uri, &client_content);
+
+    let results = backend
+        .find_references(
+            &functions_uri,
+            &functions_content,
+            Position::new(3, 9),
+            true,
+        )
+        .expect("should find function references");
+
+    assert_no_duplicates(&results, "function_alias_refs");
+    assert!(
+        results.iter().any(|loc| loc.uri.as_str() == client_uri),
+        "Expected aliased baz() call in client.php, got {:#?}",
+        results
+    );
+}
+
 // ─── $this references ───────────────────────────────────────────────────────
 
 #[test]
@@ -572,6 +635,66 @@ class Baz {
         results.len() >= 2,
         "Expected at least 2 cross-file references, got {}: {:#?}",
         results.len(),
+        results
+    );
+}
+
+#[test]
+fn class_references_include_aliased_import_usage() {
+    let (backend, dir) = crate::common::create_psr4_workspace(
+        r#"{
+            "autoload": {
+                "psr-4": {
+                    "App\\": "src/"
+                }
+            }
+        }"#,
+        &[
+            (
+                "src/Models/User.php",
+                r#"<?php
+namespace App\Models;
+
+class User {}
+"#,
+            ),
+            (
+                "src/Controller.php",
+                r#"<?php
+namespace App;
+
+use App\Models\User as Account;
+
+class Controller {
+    public function show(): void {
+        $user = new Account();
+    }
+}
+"#,
+            ),
+        ],
+    );
+
+    let user_path = dir.path().join("src/Models/User.php");
+    let controller_path = dir.path().join("src/Controller.php");
+
+    let user_uri = format!("file://{}", user_path.display());
+    let controller_uri = format!("file://{}", controller_path.display());
+
+    let user_content = std::fs::read_to_string(&user_path).unwrap();
+    let controller_content = std::fs::read_to_string(&controller_path).unwrap();
+
+    open_file(&backend, &user_uri, &user_content);
+    open_file(&backend, &controller_uri, &controller_content);
+
+    let results = backend
+        .find_references(&user_uri, &user_content, Position::new(3, 6), true)
+        .expect("should find class references");
+
+    assert_no_duplicates(&results, "class_alias_refs");
+    assert!(
+        results.iter().any(|loc| loc.uri.as_str() == controller_uri),
+        "Expected aliased Account usage in Controller.php, got {:#?}",
         results
     );
 }
@@ -1578,6 +1701,70 @@ class Cart {
     }
 
     assert_no_duplicates(&results, "one_file_method_refs");
+}
+
+#[test]
+fn workspace_index_refreshes_after_new_file_is_added() {
+    let (backend, dir) = crate::common::create_psr4_workspace(
+        r#"{
+            "autoload": {
+                "psr-4": {
+                    "App\\": "src/"
+                }
+            }
+        }"#,
+        &[(
+            "src/Item.php",
+            r#"<?php
+namespace App;
+
+class Item {}
+"#,
+        )],
+    );
+
+    let item_path = dir.path().join("src/Item.php");
+    let item_uri = format!("file://{}", item_path.display());
+    let item_content = std::fs::read_to_string(&item_path).unwrap();
+
+    open_file(&backend, &item_uri, &item_content);
+
+    let initial_results = backend
+        .find_references(&item_uri, &item_content, Position::new(3, 6), true)
+        .expect("should find initial class references");
+
+    assert_no_duplicates(&initial_results, "workspace_refresh_initial_refs");
+
+    let service_path = dir.path().join("src/Service.php");
+    std::fs::write(
+        &service_path,
+        r#"<?php
+namespace App;
+
+use App\Item;
+
+class Service {
+    public function build(): void {
+        $item = new Item();
+    }
+}
+"#,
+    )
+    .expect("failed to write newly added PHP file");
+
+    let service_uri = format!("file://{}", service_path.display());
+    let refreshed_results = backend
+        .find_references(&item_uri, &item_content, Position::new(3, 6), true)
+        .expect("should find refreshed class references");
+
+    assert_no_duplicates(&refreshed_results, "workspace_refresh_refs");
+    assert!(
+        refreshed_results
+            .iter()
+            .any(|loc| loc.uri.as_str() == service_uri),
+        "Expected newly added Service.php to be discovered, got {:#?}",
+        refreshed_results
+    );
 }
 
 // ─── Nullable / union type member references ────────────────────────────────


### PR DESCRIPTION
  ## Summary

  Improves project-wide Find References in two ways: it now avoids reading most
  files from disk by filtering on pre-built span metadata before touching content,
  and it discovers PHP files that were added to the workspace after the editor
  started. A separate fix removes a deadlock in the virtual-member (PHPDoc mixin)
  resolution cache.

  ## Changes

  - **Adds span-only pre-filter to all cross-file reference scanners.** Before
    loading any file content, each scanner now checks whether the file's symbol
    spans contain a name that could plausibly match the target. Files with no
    candidate spans are skipped entirely. Applies to class, member, function,
    constant, and Laravel string-key reference searches.
  - **Makes file content loading lazy.** Content is now read from disk only after
    a span passes the pre-filter, instead of being loaded upfront for every file
    in the workspace.
  - **Replaces the O(N·classes) descendant walk with a GTI-index BFS.** The
    previous algorithm iterated every known class on each expansion step to find
    subclasses. The new algorithm does a breadth-first walk of the precomputed
    `gti_index` (the reverse-inheritance map built by Go-to-Implementation),
    reducing the traversal from O(depth × total_classes) to O(hierarchy_size).
  - **Refreshes workspace index on subsequent searches.** `ensure_workspace_indexed`
    now re-runs the filesystem walk on every call, but only parses files not yet
    in `symbol_maps`. A new `workspace_indexed: AtomicBool` flag lets the code log
    whether it is doing an initial scan or a cheaper refresh walk.
  - **Fixes virtual-member cache deadlock.** In `phpdoc.rs`, the Mutex guard for
    the shared mixin cache was held across an `else` branch that attempted to
    acquire a thread-local cache — which could deadlock in some call paths. Fixed
    by extracting the `map.get()` result with `Arc::clone` before releasing the
    guard.
  - **Fixes lock-hold scope in `resolve_class_fully_inner`.** The `cache.lock()`
    call now immediately chains `.insert()` rather than holding the guard across a
    separate assignment.
  - **Adds deduplication in `find_class_references`.** Calls `locations.dedup()`
    after the sort to remove any duplicate entries that survived the unique-push
    logic.
  - **Adds tracing instrumentation.** `find_references` and
    `ensure_workspace_indexed` now emit `tracing::info!` timing spans, making it
    easy to measure performance from LSP logs.
  - **Adds `benches/references.rs` benchmark suite.**

  ## How It Works

  **Pre-filter + lazy load (class / function / member / constant references):**

  1. For each file in the workspace snapshot, scan only `symbol_map.spans`
     target — accounting for aliased imports (`use Foo as Bar`) by resolving
     through `file_imports`.
  2. Files with no candidate span are skipped with `continue` before any
     `Url::parse` or `get_file_content_arc` call.
  3. Within a passing file, `file_content` is a lazy `Option<Arc<String>>` that
     is only populated on the first span that actually matches.

  **Descendant collection via `gti_index`:**

  - `collect_class_hierarchy` seeds a `HashSet` with the target FQN and its
    ancestors (unchanged), then does a BFS over `gti_index` — a
    `HashMap<String, Vec<String>>` that maps each FQN to its direct subclasses.
  - New subclasses are pushed onto a `VecDeque`; the loop terminates naturally
    when no new entries are found. The old iterative O(N) loop and the helper
    methods `class_is_descendant_of` / `ancestor_in_set` are removed.

  **Workspace freshness:**

  - `ensure_workspace_indexed` is called once per `find_references` request
    (already behind `tokio::spawn` so it does not block the LSP thread).
  - On the first call, `workspace_indexed` is `false`; the full disk walk runs and
    all new files are parsed. The flag is set to `true` after the walk.
  - On subsequent calls, the walk runs again but `phase2_work` contains only files
    whose URIs are absent from `symbol_maps` — so only newly created files pay the
    parse cost.

  ## Tests

  New tests in `tests/integration/references.rs`:

  - `function_references_include_aliased_import_usage` — verifies that
    `use function Foo\bar as baz; baz()` is found when searching for `Foo\bar`.
  - `class_references_include_aliased_import_usage` — verifies that
    `use App\Models\User as Account; new Account()` is found when searching for
    `App\Models\User`.
  - `workspace_index_refreshes_after_new_file_is_added` — writes a new PHP file
    to disk after the initial index, then calls find references again and asserts
    the newly created file appears in the results.