### PR TITLE
Use locked install

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -11,7 +11,7 @@ brew install phpantom-lsp
 ### Cargo
 
 ```bash
-cargo install phpantom_lsp
+cargo install phpantom_lsp --locked
 ```
 
 See [phpantom_lsp on crates.io](https://crates.io/crates/phpantom_lsp).


### PR DESCRIPTION
Currently `cargo install phpantom_lsp` fails to install `phpantom_lsp` as `mago` had a breaking change. 

This leads to multiple of hundreds mismatched types errors:
```rust
 developer > ~ > cargo install phpantom_lsp
    Updating crates.io index
  Downloaded phpantom_lsp v0.8.0
  Downloaded 1 crate (2.7MiB) in 0.89s
  Installing phpantom_lsp v0.8.0
    Updating crates.io index
     Locking 275 packages to latest compatible versions
  Downloaded Inflector v0.11.4
  Downloaded schemars_derive v1.2.1
  Downloaded mago-php-version v1.28.0
...
   Compiling mago-syntax v1.28.0
   Compiling tower-lsp v0.20.0
   Compiling mago-formatter v1.28.0
   Compiling mago-docblock v1.28.0
   Compiling mago-names v1.28.0
error[E0308]: mismatched types
   --> /home/developer/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/phpantom_lsp-0.8.0/src/code_actions/change_visibility.rs:103:56
    |
103 |         let file_id = mago_database::file::FileId::new("input.php");
    |                       -------------------------------- ^^^^^^^^^^^ expected `&[u8]`, found `&str`
    |                       |
    |                       arguments to this function are incorrect
    |
    = note: expected reference `&[u8]`
               found reference `&'static str`
note: associated function defined here
   --> /home/developer/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/mago-database-1.28.0/src/file.rs:221:12
    |
221 |     pub fn new(logical_name: &[u8]) -> Self {
    |            ^^^
help: consider adding a leading `b`
    |
103 |         let file_id = mago_database::file::FileId::new(b"input.php");
    |                                                        +
    ...
    error[E0277]: can't compare `&[u8]` with `std::string::String`
  --> /home/developer/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/phpantom_lsp-0.8.0/src/virtual_members/laravel/trans_keys.rs:88:28
   |
88 |                 && dv.name == var_name
   |                            ^^ no implementation for `&[u8] == std::string::String`
   |
   = help: the trait `PartialEq<std::string::String>` is not implemented for `&[u8]`
   = help: the following other types implement trait `PartialEq<Rhs>`:
             `&[u8]` implements `PartialEq<ByteStr>`
             `&[u8]` implements `PartialEq<ByteString>`
             `&[u8]` implements `PartialEq<bstr::bstr::BStr>`
             `&[u8]` implements `PartialEq<bstr::bstring::BString>`
             `&[u8]` implements `PartialEq<bytes::bytes::Bytes>`
             `&[u8]` implements `PartialEq<bytes::bytes_mut::BytesMut>`
             `&[u8]` implements `PartialEq<winnow::stream::bstr::BStr>`
             `&[u8]` implements `PartialEq<winnow::stream::bytes::Bytes>`
           and 8 others

error[E0308]: mismatched types
   --> /home/developer/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/phpantom_lsp-0.8.0/src/virtual_members/laravel/trans_keys.rs:117:55
    |
117 |                 && ident.value().eq_ignore_ascii_case("array_merge")
    |                                  -------------------- ^^^^^^^^^^^^^ expected `&[u8]`, found `&str`
    |                                  |
    |                                  arguments to this method are incorrect
    |
    = note: expected reference `&[u8]`
               found reference `&'static str`
note: method defined here
   --> /home/developer/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/ascii.rs:60:18
    |
 60 |     pub const fn eq_ignore_ascii_case(&self, other: &[u8]) -> bool {
    |                  ^^^^^^^^^^^^^^^^^^^^
help: consider adding a leading `b`
    |
117 |                 && ident.value().eq_ignore_ascii_case(b"array_merge")
    |                                                       +

Some errors have detailed explanations: E0271, E0277, E0308, E0599.
For more information about an error, try `rustc --explain E0271`.
error: could not compile `phpantom_lsp` (lib) due to 580 previous errors
error: failed to compile `phpantom_lsp v0.8.0`, intermediate artifacts can be found at `/tmp/cargo-installKq5GYt`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_BUILD_BUILD_DIR` to that path.
```

The recommended way to mitigate the issue is just to use the `cargo.lock` when installing, to always use the locked dependencies