### PR TITLE
Fix setup instruction for officiail php extension for Zed

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -48,7 +48,7 @@ PHPantom is supported directly by Zed's official PHP extension, no separate PHPa
 {
   "languages": {
     "PHP": {
-      "language_servers": ["phpantom_lsp", "!intelephense", "!phpactor", "!phptools", "..."]
+      "language_servers": ["phpantom", "!intelephense", "!phpactor", "!phptools", "..."]
     }
   }
 }


### PR DESCRIPTION
The offical php extension registers the server as `phpantom` (without `_lsp` suffix)